### PR TITLE
Simplify metadata and record fields access

### DIFF
--- a/seabolt-cli/src/main.c
+++ b/seabolt-cli/src/main.c
@@ -315,26 +315,24 @@ int app_run(struct Application * app, const char * cypher)
     BoltConnection_fetch_summary(app->connection, run);
     if (app->with_header)
     {
-        struct BoltValue * name = BoltValue_create();
-        for (int i = 0; i < BoltConnection_result_n_fields(app->connection); i++)
+        const struct BoltValue * fields = BoltConnection_metadata_fields(app->connection);
+        for (int i = 0; i < fields->size; i++)
         {
             if (i > 0)
             {
                 putc('\t', stdout);
             }
-            BoltValue_format_as_String(name, BoltConnection_result_field_name(app->connection, i),
-                                       BoltConnection_result_field_name_size(app->connection, i));
-            BoltValue_write(name, stdout, app->connection->protocol_version);
+            BoltValue_write(BoltList_value(fields, i), stdout, app->connection->protocol_version);
         }
         putc('\n', stdout);
-        BoltValue_destroy(name);
     }
 
     while (BoltConnection_fetch(app->connection, pull))
     {
-        for (int i = 0; i < BoltConnection_record_size(app->connection); i++)
+        const struct BoltValue * field_values = BoltConnection_record_fields(app->connection);
+        for (int i = 0; i < field_values->size; i++)
         {
-            struct BoltValue * value = BoltConnection_record_field(app->connection, i);
+            struct BoltValue * value = BoltList_value(field_values, i);
             if (i > 0)
             {
                 putc('\t', stdout);

--- a/seabolt-test/src/test_direct.cpp
+++ b/seabolt-test/src/test_direct.cpp
@@ -282,16 +282,19 @@ SCENARIO("Test field names returned from Cypher execution", "[integration][ipv6]
             BoltConnection_send(connection);
             bolt_request_t last = BoltConnection_last_request(connection);
             BoltConnection_fetch_summary(connection, run);
-            int n_fields = BoltConnection_result_n_fields(connection);
-            REQUIRE(n_fields == 3);
-            const char * field_name = BoltConnection_result_field_name(connection, 0);
-            int field_name_size = BoltConnection_result_field_name_size(connection, 0);
+            const struct BoltValue * fields = BoltConnection_metadata_fields(connection);
+            REQUIRE(fields->size == 3);
+            struct BoltValue * field_name_value = BoltList_value(fields, 0);
+            const char * field_name =  BoltString_get(field_name_value);
+            int field_name_size = field_name_value->size;
             REQUIRE(strncmp(field_name, "first", field_name_size) == 0);
-            field_name = BoltConnection_result_field_name(connection, 1);
-            field_name_size = BoltConnection_result_field_name_size(connection, 1);
+            field_name_value = BoltList_value(fields, 1);
+            field_name = BoltString_get(field_name_value);
+            field_name_size = field_name_value->size;
             REQUIRE(strncmp(field_name, "second", field_name_size) == 0);
-            field_name = BoltConnection_result_field_name(connection, 2);
-            field_name_size = BoltConnection_result_field_name_size(connection, 2);
+            field_name_value = BoltList_value(fields, 2);
+            field_name = BoltString_get(field_name_value);
+            field_name_size = field_name_value->size;
             REQUIRE(strncmp(field_name, "third", field_name_size) == 0);
             REQUIRE(field_name_size == 5);
             BoltConnection_fetch_summary(connection, last);
@@ -321,7 +324,8 @@ SCENARIO("Test parameterised Cypher statements", "[integration][ipv6][secure]")
             REQUIRE(BoltConnection_summary_success(connection) == 1);
             while (BoltConnection_fetch(connection, pull))
             {
-                struct BoltValue * value = BoltConnection_record_field(connection, 0);
+                const struct BoltValue * field_values = BoltConnection_record_fields(connection);
+                struct BoltValue * value = BoltList_value(field_values, 0);
                 REQUIRE(BoltValue_type(value) == BOLT_INTEGER);
                 REQUIRE(BoltInteger_get(value) == 42);
                 records += 1;
@@ -392,7 +396,8 @@ SCENARIO("Test transactions", "[integration][ipv6][secure]")
 
             while (BoltConnection_fetch(connection, pull))
             {
-                BoltValue * value = BoltConnection_record_field(connection, 0);
+                const struct BoltValue * field_values = BoltConnection_record_fields(connection);
+                struct BoltValue * value = BoltList_value(field_values, 0);
                 REQUIRE(BoltValue_type(value) == BOLT_INTEGER);
                 REQUIRE(BoltInteger_get(value) == 1);
                 records += 1;

--- a/seabolt-test/src/test_values.cpp
+++ b/seabolt-test/src/test_values.cpp
@@ -53,7 +53,8 @@ SCENARIO("Test null parameter", "[integration][ipv6][secure]")
             RUN_PULL_SEND(connection, result);
             while (BoltConnection_fetch(connection, result))
             {
-                struct BoltValue * value = BoltConnection_record_field(connection, 0);
+                const struct BoltValue * field_values = BoltConnection_record_fields(connection);
+                struct BoltValue * value = BoltList_value(field_values, 0);
                 REQUIRE_BOLT_NULL(value);
             }
             REQUIRE_BOLT_SUCCESS(connection);
@@ -76,7 +77,8 @@ SCENARIO("Test boolean in, boolean out", "[integration][ipv6][secure]")
             RUN_PULL_SEND(connection, result);
             while (BoltConnection_fetch(connection, result))
             {
-                struct BoltValue * value = BoltConnection_record_field(connection, 0);
+                const struct BoltValue * field_values = BoltConnection_record_fields(connection);
+                struct BoltValue * value = BoltList_value(field_values, 0);
                 REQUIRE_BOLT_BOOLEAN(value, 1);
             }
             REQUIRE_BOLT_SUCCESS(connection);
@@ -100,7 +102,8 @@ SCENARIO("Test bytes in, bytes out", "[integration][ipv6][secure]")
             RUN_PULL_SEND(connection, result);
             while (BoltConnection_fetch(connection, result))
             {
-                struct BoltValue * value = BoltConnection_record_field(connection, 0);
+                const struct BoltValue * field_values = BoltConnection_record_fields(connection);
+                struct BoltValue * value = BoltList_value(field_values, 0);
                 REQUIRE_BOLT_BYTES(value, 5);
             }
             REQUIRE_BOLT_SUCCESS(connection);
@@ -123,7 +126,8 @@ SCENARIO("Test string in, string out", "[integration][ipv6][secure]")
             RUN_PULL_SEND(connection, result);
             while (BoltConnection_fetch(connection, result))
             {
-                struct BoltValue * value = BoltConnection_record_field(connection, 0);
+                const struct BoltValue * field_values = BoltConnection_record_fields(connection);
+                struct BoltValue * value = BoltList_value(field_values, 0);
                 REQUIRE_BOLT_STRING(value, "hello, world", 12);
             }
             REQUIRE_BOLT_SUCCESS(connection);
@@ -150,7 +154,8 @@ SCENARIO("Test dictionary in, dictionary out", "[integration][ipv6][secure]")
             RUN_PULL_SEND(connection, result);
             while (BoltConnection_fetch(connection, result))
             {
-                struct BoltValue * dict = BoltConnection_record_field(connection, 0);
+                const struct BoltValue * field_values = BoltConnection_record_fields(connection);
+                struct BoltValue * dict = BoltList_value(field_values, 0);
                 REQUIRE_BOLT_DICTIONARY(dict, 2);
                 int found = 0;
                 for (int i = 0; i < dict->size; i++)
@@ -193,7 +198,8 @@ SCENARIO("Test integer in, integer out", "[integration][ipv6][secure]")
             RUN_PULL_SEND(connection, result);
             while (BoltConnection_fetch(connection, result))
             {
-                struct BoltValue * value = BoltConnection_record_field(connection, 0);
+                const struct BoltValue * field_values = BoltConnection_record_fields(connection);
+                struct BoltValue * value = BoltList_value(field_values, 0);
                 REQUIRE_BOLT_INTEGER(value, 123456789);
             }
             REQUIRE_BOLT_SUCCESS(connection);
@@ -216,7 +222,8 @@ SCENARIO("Test float in, float out", "[integration][ipv6][secure]")
             RUN_PULL_SEND(connection, result);
             while (BoltConnection_fetch(connection, result))
             {
-                struct BoltValue * value = BoltConnection_record_field(connection, 0);
+                const struct BoltValue * field_values = BoltConnection_record_fields(connection);
+                struct BoltValue * value = BoltList_value(field_values, 0);
                 REQUIRE_BOLT_FLOAT(value, 6.283185307179);
             }
             REQUIRE_BOLT_SUCCESS(connection);
@@ -243,7 +250,8 @@ SCENARIO("Test structure in result", "[integration][ipv6][secure]")
             bolt_request_t last = BoltConnection_last_request(connection);
             while (BoltConnection_fetch(connection, result))
             {
-                struct BoltValue * node = BoltConnection_record_field(connection, 0);
+                const struct BoltValue * field_values = BoltConnection_record_fields(connection);
+                struct BoltValue * node = BoltList_value(field_values, 0);
                 REQUIRE_BOLT_STRUCTURE(node, 'N', 3);
                 BoltValue * id = BoltStructure_value(node, 0);
                 BoltValue * labels = BoltStructure_value(node, 1);

--- a/seabolt/include/bolt/connections.h
+++ b/seabolt/include/bolt/connections.h
@@ -76,6 +76,7 @@ enum BoltConnectionError
     BOLT_TLS_ERROR,             // general catch-all for OpenSSL errors :/
     BOLT_PROTOCOL_VIOLATION,
     BOLT_END_OF_TRANSMISSION,
+    BOLT_SERVER_FAILURE,
 };
 
 /**
@@ -288,22 +289,6 @@ PUBLIC int BoltConnection_fetch(struct BoltConnection * connection, bolt_request
 PUBLIC int BoltConnection_fetch_summary(struct BoltConnection * connection, bolt_request_t request);
 
 /**
- * Obtain a value from the current record.
- *
- * @param connection
- * @param field
- * @return pointer to a `BoltValue` data structure formatted as a BOLT_LIST
- */
-PUBLIC const struct BoltValue * BoltConnection_record_fields(struct BoltConnection * connection);
-
-/**
- *
- * @param connection
- * @return
- */
-PUBLIC int BoltConnection_summary_success(struct BoltConnection * connection);
-
-/**
  * Set the next Cypher statement template to be run on this connection.
  *
  * @param connection
@@ -326,6 +311,9 @@ PUBLIC int BoltConnection_cypher(struct BoltConnection * connection, const char 
  */
 PUBLIC struct BoltValue * BoltConnection_cypher_parameter(struct BoltConnection * connection, int32_t index,
                                                           const char * key, size_t key_size);
+
+
+PUBLIC int BoltConnection_ack_failure(struct BoltConnection * connection);
 
 /**
  * Load a bookmark to be used when beginning the next transaction.
@@ -396,12 +384,36 @@ PUBLIC int BoltConnection_load_pull_request(struct BoltConnection * connection, 
 PUBLIC bolt_request_t BoltConnection_last_request(struct BoltConnection * connection);
 
 /**
+* Obtain a value from the current record.
+*
+* @param connection
+* @param field
+* @return pointer to a `BoltValue` data structure formatted as a BOLT_LIST
+*/
+PUBLIC struct BoltValue * BoltConnection_record_fields(struct BoltConnection * connection);
+
+/**
+*
+* @param connection
+* @return
+*/
+PUBLIC int BoltConnection_summary_success(struct BoltConnection * connection);
+
+/**
+ * Obtain the details of the latest server generated FAILURE message
+ *
+ * @param connection
+ * @return
+ */
+PUBLIC struct BoltValue * BoltConnection_failure(struct BoltConnection * connection);
+
+/**
  * Return the number of fields available in the current result.
  *
  * @param connection
  * @return
  */
-PUBLIC const struct BoltValue * BoltConnection_metadata_fields(struct BoltConnection * connection);
+PUBLIC struct BoltValue * BoltConnection_metadata_fields(struct BoltConnection * connection);
 
 
 #endif // SEABOLT_CONNECT

--- a/seabolt/include/bolt/connections.h
+++ b/seabolt/include/bolt/connections.h
@@ -294,15 +294,7 @@ PUBLIC int BoltConnection_fetch_summary(struct BoltConnection * connection, bolt
  * @param field
  * @return pointer to a `BoltValue` data structure formatted as a BOLT_LIST
  */
-PUBLIC struct BoltValue * BoltConnection_record_field(struct BoltConnection * connection, int32_t field);
-
-/**
- *
- *
- * @param connection
- * @return
- */
-PUBLIC int32_t BoltConnection_record_size(struct BoltConnection * connection);
+PUBLIC const struct BoltValue * BoltConnection_record_fields(struct BoltConnection * connection);
 
 /**
  *
@@ -409,25 +401,7 @@ PUBLIC bolt_request_t BoltConnection_last_request(struct BoltConnection * connec
  * @param connection
  * @return
  */
-PUBLIC int32_t BoltConnection_result_n_fields(struct BoltConnection * connection);
-
-/**
- * Return the name of a specific field in the current result.
- *
- * @param connection
- * @param index
- * @return
- */
-PUBLIC const char * BoltConnection_result_field_name(struct BoltConnection * connection, int32_t index);
-
-/**
- * Return the size of the name of a specific field in the current result.
- *
- * @param connection
- * @param index
- * @return
- */
-PUBLIC int32_t BoltConnection_result_field_name_size(struct BoltConnection * connection, int32_t index);
+PUBLIC const struct BoltValue * BoltConnection_metadata_fields(struct BoltConnection * connection);
 
 
 #endif // SEABOLT_CONNECT

--- a/seabolt/include/bolt/values.h
+++ b/seabolt/include/bolt/values.h
@@ -199,7 +199,7 @@ PUBLIC void BoltValue_format_as_String(struct BoltValue * value, const char * da
 
 PUBLIC char* BoltString_get(struct BoltValue * value);
 
-
+PUBLIC int BoltString_equals(struct BoltValue * value, const char * data);
 
 PUBLIC void BoltValue_format_as_Dictionary(struct BoltValue * value, int32_t length);
 
@@ -209,10 +209,13 @@ PUBLIC const char * BoltDictionary_get_key(struct BoltValue * value, int32_t ind
 
 PUBLIC int32_t BoltDictionary_get_key_size(struct BoltValue * value, int32_t index);
 
+PUBLIC int32_t BoltDictionary_get_key_index(struct BoltValue * value, const char * key, size_t key_size, int32_t start_index);
+
 PUBLIC int BoltDictionary_set_key(struct BoltValue * value, int32_t index, const char * key, size_t key_size);
 
 PUBLIC struct BoltValue * BoltDictionary_value(struct BoltValue * value, int32_t index);
 
+PUBLIC struct BoltValue * BoltDictionary_value_by_key(struct BoltValue * value, const char * key, size_t key_size);
 
 
 /**

--- a/seabolt/src/bolt/connections.c
+++ b/seabolt/src/bolt/connections.c
@@ -26,6 +26,7 @@
 
 #include "protocol/v1.h"
 #include "bolt/platform.h"
+#include <assert.h>
 
 
 #define INITIAL_TX_BUFFER_SIZE 8192
@@ -518,7 +519,7 @@ int BoltConnection_fetch(struct BoltConnection * connection, bolt_request_t requ
     {
         case 1:
         {
-            int fetched = BoltProtocolV1_fetch(connection, request);
+            const int fetched = BoltProtocolV1_fetch(connection, request);
             if (fetched == 0)
             {
                 // Summary received
@@ -529,10 +530,16 @@ int BoltConnection_fetch(struct BoltConnection * connection, bolt_request_t requ
                         _set_status(connection, BOLT_READY, BOLT_NO_ERROR);
                         return 0;
                     case BOLT_V1_IGNORED:
-                        // Leave status as-is
+                        // we may need to update status based on an earlier reported FAILURE
+                        // which our consumer did not care its result
+                        if (state->failure_data != NULL)
+                        {
+                            _set_status(connection, BOLT_FAILED, BOLT_SERVER_FAILURE);
+                        }
+
                         return 0;
                     case BOLT_V1_FAILURE:
-                        _set_status(connection, BOLT_FAILED, BOLT_UNKNOWN_ERROR);   // TODO more specific error
+                        _set_status(connection, BOLT_FAILED, BOLT_SERVER_FAILURE);
                         return 0;
                     default:
                         BoltLog_error("bolt: Protocol violation (received summary code %d)", state->data_type);
@@ -567,7 +574,7 @@ int BoltConnection_fetch_summary(struct BoltConnection * connection, bolt_reques
     return records;
 }
 
-const struct BoltValue* BoltConnection_record_fields(struct BoltConnection * connection)
+struct BoltValue* BoltConnection_record_fields(struct BoltConnection * connection)
 {
     switch (connection->protocol_version)
     {
@@ -711,6 +718,37 @@ struct BoltValue * BoltConnection_cypher_parameter(struct BoltConnection * conne
     }
 }
 
+int BoltConnection_ack_failure(struct BoltConnection* connection)
+{
+    assert(BoltConnection_failure(connection) != NULL);
+
+    switch (connection->protocol_version)
+    {
+    case 1:
+        BoltProtocolV1_load_ack_failure(connection);
+        BoltProtocolV1_clear_failure(connection);
+        break;
+    default:
+        return -1;
+    }
+
+    const bolt_request_t ack_failure = BoltConnection_last_request(connection);
+    TRY(BoltConnection_send(connection));
+    const int status = BoltConnection_fetch_summary(connection, ack_failure);
+    if (status < 0)
+    {
+        return -1;
+    }
+
+    if (!BoltConnection_summary_success(connection))
+    {
+        return -1;
+    }
+
+    return 0;
+}
+
+
 int BoltConnection_load_bookmark(struct BoltConnection * connection, const char * bookmark)
 {
     switch (connection->protocol_version)
@@ -818,7 +856,7 @@ bolt_request_t BoltConnection_last_request(struct BoltConnection * connection)
     }
 }
 
-const struct BoltValue * BoltConnection_metadata_fields(struct BoltConnection * connection)
+struct BoltValue * BoltConnection_metadata_fields(struct BoltConnection * connection)
 {
     switch (connection->protocol_version)
     {
@@ -826,5 +864,24 @@ const struct BoltValue * BoltConnection_metadata_fields(struct BoltConnection * 
             return BoltProtocolV1_result_fields(connection);
         default:
             return NULL;
+    }
+}
+
+struct BoltValue * BoltConnection_failure(struct BoltConnection * connection)
+{
+    switch (connection->protocol_version)
+    {
+    case 1:
+    {
+        struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
+        if (state == NULL)
+        {
+            return NULL;
+        }
+
+        return state->failure_data;
+    }
+    default:
+        return NULL;
     }
 }

--- a/seabolt/src/bolt/connections.c
+++ b/seabolt/src/bolt/connections.c
@@ -567,7 +567,7 @@ int BoltConnection_fetch_summary(struct BoltConnection * connection, bolt_reques
     return records;
 }
 
-struct BoltValue* BoltConnection_record_field(struct BoltConnection * connection, int32_t field)
+const struct BoltValue* BoltConnection_record_fields(struct BoltConnection * connection)
 {
     switch (connection->protocol_version)
     {
@@ -582,7 +582,7 @@ struct BoltValue* BoltConnection_record_field(struct BoltConnection * connection
                         case BOLT_LIST:
                         {
                             struct BoltValue * values = BoltList_value(state->data, 0);
-                            return BoltList_value(values, field);
+                            return values;
                         }
                         default:
                             return NULL;
@@ -593,35 +593,6 @@ struct BoltValue* BoltConnection_record_field(struct BoltConnection * connection
         }
         default:
             return NULL;
-    }
-}
-
-int32_t BoltConnection_record_size(struct BoltConnection * connection)
-{
-    switch (connection->protocol_version)
-    {
-        case 1:
-        {
-            struct BoltProtocolV1State * state = BoltProtocolV1_state(connection);
-            switch (state->data_type)
-            {
-                case BOLT_V1_RECORD:
-                    switch (BoltValue_type(state->data))
-                    {
-                        case BOLT_LIST:
-                        {
-                            struct BoltValue * values = BoltList_value(state->data, 0);
-                            return values->size;
-                        }
-                        default:
-                            return -1;
-                    }
-                default:
-                    return -1;
-            }
-        }
-        default:
-            return -1;
     }
 }
 
@@ -847,35 +818,13 @@ bolt_request_t BoltConnection_last_request(struct BoltConnection * connection)
     }
 }
 
-int32_t BoltConnection_result_n_fields(struct BoltConnection * connection)
+const struct BoltValue * BoltConnection_metadata_fields(struct BoltConnection * connection)
 {
     switch (connection->protocol_version)
     {
         case 1:
-            return BoltProtocolV1_n_result_fields(connection);
-        default:
-            return -1;
-    }
-}
-
-const char * BoltConnection_result_field_name(struct BoltConnection * connection, int32_t index)
-{
-    switch (connection->protocol_version)
-    {
-        case 1:
-            return BoltProtocolV1_result_field_name(connection, index);
+            return BoltProtocolV1_result_fields(connection);
         default:
             return NULL;
-    }
-}
-
-int32_t BoltConnection_result_field_name_size(struct BoltConnection * connection, int32_t index)
-{
-    switch (connection->protocol_version)
-    {
-        case 1:
-            return BoltProtocolV1_result_field_name_size(connection, index);
-        default:
-            return -1;
     }
 }

--- a/seabolt/src/bolt/protocol/v1.c
+++ b/seabolt/src/bolt/protocol/v1.c
@@ -112,6 +112,7 @@ struct BoltProtocolV1State* BoltProtocolV1_create_state()
     state->server = BoltMem_allocate(MAX_SERVER_SIZE);
     memset(state->server, 0, MAX_SERVER_SIZE);
     state->result_field_names = BoltValue_create();
+    state->failure_data = NULL;
     state->last_bookmark = BoltMem_allocate(MAX_BOOKMARK_SIZE);
     memset(state->last_bookmark, 0, MAX_BOOKMARK_SIZE);
 
@@ -125,6 +126,8 @@ struct BoltProtocolV1State* BoltProtocolV1_create_state()
     BoltValue_format_as_String(state->commit.statement, "COMMIT", 6);
     compile_RUN(&state->rollback, 0);
     BoltValue_format_as_String(state->rollback.statement, "ROLLBACK", 8);
+
+    state->ackfailure_request = BoltMessage_create(ACK_FAILURE, 0);
 
     state->discard_request = BoltMessage_create(DISCARD_ALL, 0);
 
@@ -149,12 +152,17 @@ void BoltProtocolV1_destroy_state(struct BoltProtocolV1State* state)
     BoltMessage_destroy(state->commit.request);
     BoltMessage_destroy(state->rollback.request);
 
+    BoltMessage_destroy(state->ackfailure_request);
     BoltMessage_destroy(state->discard_request);
     BoltMessage_destroy(state->pull_request);
 
     BoltMessage_destroy(state->reset_request);
 
     BoltMem_deallocate(state->server, MAX_SERVER_SIZE);
+    if (state->failure_data != NULL)
+    {
+        BoltValue_destroy(state->failure_data);
+    }
     BoltValue_destroy(state->result_field_names);
     BoltMem_deallocate(state->last_bookmark, MAX_BOOKMARK_SIZE);
 
@@ -813,6 +821,26 @@ int unload(struct BoltConnection * connection, struct BoltValue * value)
     }
 }
 
+void ensure_failure_data(struct BoltProtocolV1State * state)
+{
+    if (state->failure_data == NULL)
+    {
+        state->failure_data = BoltValue_create();
+        BoltValue_format_as_Dictionary(state->failure_data, 2);
+        BoltDictionary_set_key(state->failure_data, 0, "code", strlen("code"));
+        BoltDictionary_set_key(state->failure_data, 1, "message", strlen("message"));
+    }
+}
+
+void clear_failure_data(struct BoltProtocolV1State * state)
+{
+    if (state->failure_data != NULL)
+    {
+        BoltValue_destroy(state->failure_data);
+        state->failure_data = NULL;
+    }
+}
+
 int BoltProtocolV1_fetch(struct BoltConnection * connection, bolt_request_t request_id)
 {
     struct BoltProtocolV1State * state = BoltProtocolV1_state(connection);
@@ -850,13 +878,19 @@ int BoltProtocolV1_fetch(struct BoltConnection * connection, bolt_request_t requ
         if (state->data_type != BOLT_V1_RECORD)
         {
             state->response_counter += 1;
+
+            if (state->data->size >= 1)
+            {
+                BoltProtocolV1_extract_metadata(connection, BoltList_value(state->data, 0));
+            }
         }
     } while (response_id != request_id);
-    if (state->data_type != BOLT_V1_RECORD && state->data->size >= 1)
+
+    if (state->data_type != BOLT_V1_RECORD)
     {
-        BoltProtocolV1_extract_metadata(connection, BoltList_value(state->data, 0));
         return 0;
     }
+
     return 1;
 }
 
@@ -979,6 +1013,12 @@ int BoltProtocolV1_reset(struct BoltConnection * connection)
     return state->data_type;
 }
 
+void BoltProtocolV1_clear_failure(struct BoltConnection * connection)
+{
+    struct BoltProtocolV1State * state = BoltProtocolV1_state(connection);
+    clear_failure_data(state);
+}
+
 void BoltProtocolV1_extract_metadata(struct BoltConnection * connection, struct BoltValue * metadata)
 {
     struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
@@ -988,8 +1028,9 @@ void BoltProtocolV1_extract_metadata(struct BoltConnection * connection, struct 
         {
             for (int32_t i = 0; i < metadata->size; i++)
             {
-                const char * key = BoltDictionary_get_key(metadata, i);
-                if (strcmp(key, "bookmark") == 0)
+                struct BoltValue * key = BoltDictionary_key(metadata, i);
+
+                if (BoltString_equals(key, "bookmark"))
                 {
                     struct BoltValue * value = BoltDictionary_value(metadata, i);
                     switch (BoltValue_type(value))
@@ -1005,7 +1046,7 @@ void BoltProtocolV1_extract_metadata(struct BoltConnection * connection, struct 
                             break;
                     }
                 }
-                else if (strcmp(key, "fields") == 0)
+                else if (BoltString_equals(key, "fields"))
                 {
                     struct BoltValue * value = BoltDictionary_value(metadata, i);
                     switch (BoltValue_type(value))
@@ -1034,7 +1075,7 @@ void BoltProtocolV1_extract_metadata(struct BoltConnection * connection, struct 
                             break;
                     }
                 }
-                else if (strcmp(key, "server") == 0)
+                else if (BoltString_equals(key, "server"))
                 {
                     struct BoltValue * value = BoltDictionary_value(metadata, i);
                     switch (BoltValue_type(value))
@@ -1048,6 +1089,42 @@ void BoltProtocolV1_extract_metadata(struct BoltConnection * connection, struct 
                         }
                         default:
                             break;
+                    }
+                }
+                else if (BoltString_equals(key, "code") && state->data_type == BOLT_V1_FAILURE)
+                {
+                    struct BoltValue * value = BoltDictionary_value(metadata, i);
+                    switch (BoltValue_type(value))
+                    {
+                    case BOLT_STRING:
+                    {
+                        ensure_failure_data(state);
+
+                        struct BoltValue * target_value = BoltDictionary_value(state->failure_data, 0);
+                        BoltValue_format_as_String(target_value, BoltString_get(value), value->size);
+                        BoltLog_value(target_value, 1, "bolt: <FAILURE code=\"", "\">");
+                        break;
+                    }
+                    default:
+                        break;
+                    }
+                }
+                else if (BoltString_equals(key, "message") && state->data_type == BOLT_V1_FAILURE)
+                {
+                    struct BoltValue * value = BoltDictionary_value(metadata, i);
+                    switch (BoltValue_type(value))
+                    {
+                    case BOLT_STRING:
+                    {
+                        ensure_failure_data(state);
+
+                        struct BoltValue * target_value = BoltDictionary_value(state->failure_data, 1);
+                        BoltValue_format_as_String(target_value, BoltString_get(value), value->size);
+                        BoltLog_value(target_value, 1, "bolt: <FAILURE message=\"", "\">");
+                        break;
+                    }
+                    default:
+                        break;
                     }
                 }
             }
@@ -1163,6 +1240,13 @@ int BoltProtocolV1_load_pull_request(struct BoltConnection * connection, int32_t
         BoltProtocolV1_load_message(connection, state->pull_request);
         return 0;
     }
+}
+
+int BoltProtocolV1_load_ack_failure(struct BoltConnection* connection)
+{    
+    struct BoltProtocolV1State * state = BoltProtocolV1_state(connection);
+    BoltProtocolV1_load_message(connection, state->ackfailure_request);
+    return 0;
 }
 
 struct BoltValue * BoltProtocolV1_result_fields(struct BoltConnection * connection)

--- a/seabolt/src/bolt/protocol/v1.c
+++ b/seabolt/src/bolt/protocol/v1.c
@@ -1165,66 +1165,14 @@ int BoltProtocolV1_load_pull_request(struct BoltConnection * connection, int32_t
     }
 }
 
-int32_t BoltProtocolV1_n_result_fields(struct BoltConnection * connection)
+struct BoltValue * BoltProtocolV1_result_fields(struct BoltConnection * connection)
 {
     struct BoltProtocolV1State * state = BoltProtocolV1_state(connection);
     switch (BoltValue_type(state->result_field_names))
     {
         case BOLT_LIST:
-            return state->result_field_names->size;
-        default:
-            return -1;
-    }
-}
-
-const char * BoltProtocolV1_result_field_name(struct BoltConnection * connection, int32_t index)
-{
-    struct BoltProtocolV1State * state = BoltProtocolV1_state(connection);
-    switch (BoltValue_type(state->result_field_names))
-    {
-        case BOLT_LIST:
-            if (index >= 0 && index < state->result_field_names->size)
-            {
-                struct BoltValue * value = BoltList_value(state->result_field_names, index);
-                switch (BoltValue_type(value))
-                {
-                    case BOLT_STRING:
-                        return BoltString_get(value);
-                    default:
-                        return NULL;
-                }
-            }
-            else
-            {
-                return NULL;
-            }
+            return state->result_field_names;
         default:
             return NULL;
-    }
-}
-
-int32_t BoltProtocolV1_result_field_name_size(struct BoltConnection * connection, int32_t index)
-{
-    struct BoltProtocolV1State * state = BoltProtocolV1_state(connection);
-    switch (BoltValue_type(state->result_field_names))
-    {
-        case BOLT_LIST:
-            if (index >= 0 && index < state->result_field_names->size)
-            {
-                struct BoltValue * value = BoltList_value(state->result_field_names, index);
-                switch (BoltValue_type(value))
-                {
-                    case BOLT_STRING:
-                        return value->size;
-                    default:
-                        return -1;
-                }
-            }
-            else
-            {
-                return -1;
-            }
-        default:
-            return -1;
     }
 }

--- a/seabolt/src/bolt/protocol/v1.h
+++ b/seabolt/src/bolt/protocol/v1.h
@@ -72,6 +72,8 @@ struct BoltProtocolV1State
     char * server;
     /// A BoltValue containing field names for the active result
     struct BoltValue * result_field_names;
+    /// A BoltValue containing error code and message
+    struct BoltValue * failure_data;
     /// The last bookmark received from the server
     char * last_bookmark;
 
@@ -83,6 +85,8 @@ struct BoltProtocolV1State
     struct _run_request begin;
     struct _run_request commit;
     struct _run_request rollback;
+
+    struct BoltMessage * ackfailure_request;
     struct BoltMessage * discard_request;
     struct BoltMessage * pull_request;
     struct BoltMessage * reset_request;
@@ -126,6 +130,8 @@ int BoltProtocolV1_init(struct BoltConnection * connection, const struct BoltUse
 
 int BoltProtocolV1_reset(struct BoltConnection * connection);
 
+void BoltProtocolV1_clear_failure(struct BoltConnection * connection);
+
 void BoltProtocolV1_extract_metadata(struct BoltConnection * connection, struct BoltValue * summary);
 
 int BoltProtocolV1_set_cypher_template(struct BoltConnection * connection, const char * statement, size_t size);
@@ -148,6 +154,8 @@ int BoltProtocolV1_load_rollback_request(struct BoltConnection * connection);
 int BoltProtocolV1_load_run_request(struct BoltConnection * connection);
 
 int BoltProtocolV1_load_pull_request(struct BoltConnection * connection, int32_t n);
+
+int BoltProtocolV1_load_ack_failure(struct BoltConnection * connection);
 
 struct BoltValue * BoltProtocolV1_result_fields(struct BoltConnection * connection);
 

--- a/seabolt/src/bolt/protocol/v1.h
+++ b/seabolt/src/bolt/protocol/v1.h
@@ -149,11 +149,6 @@ int BoltProtocolV1_load_run_request(struct BoltConnection * connection);
 
 int BoltProtocolV1_load_pull_request(struct BoltConnection * connection, int32_t n);
 
-int32_t BoltProtocolV1_n_result_fields(struct BoltConnection * connection);
-
-const char * BoltProtocolV1_result_field_name(struct BoltConnection * connection, int32_t index);
-
-int32_t BoltProtocolV1_result_field_name_size(struct BoltConnection * connection, int32_t index);
-
+struct BoltValue * BoltProtocolV1_result_fields(struct BoltConnection * connection);
 
 #endif // SEABOLT_PROTOCOL_V1


### PR DESCRIPTION
This PR addresses the following;

1. Expose metadata/record fields through `struct BoltValue *` types instead of split function calls.
2. Support `FAILURE` messages and expose `code`/`message` through a `BoltDictionary` type with `BoltConnection_failure` method, `FAILURE` method sets connection `status`/`error` to `BOLT_FAILED`/`BOLT_SERVER_FAILURE`.
3. Support `ACK_FAILURE` through `BoltConnection_ack_failure` method. Sending `ACK_FAILURE` clears pending failure `status`/`error`.
4. Added some utility functions to value system.