### PR TITLE
Improve authentication and add bookmark retrieval support

### DIFF
--- a/seabolt-cli/src/main.c
+++ b/seabolt-cli/src/main.c
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 #include <time.h>
 
+#include "bolt/auth.h"
 #include "bolt/connections.h"
 #include "bolt/lifecycle.h"
 #include "bolt/mem.h"
@@ -187,12 +188,10 @@ int app_init(struct Application* app)
 {
     struct timespec t[2];
     timespec_get(&t[0], TIME_UTC);
-    struct BoltUserProfile profile;
-    profile.auth_scheme = BOLT_AUTH_BASIC;
-    profile.user = (char*) app->user;
-    profile.password = (char*) app->password;
-    profile.user_agent = (char*) "seabolt/1.0.0a";
-    BoltConnection_init(app->connection, &profile);
+
+    struct BoltValue* auth_token = BoltAuth_basic(app->user, app->password, NULL);
+    BoltConnection_init(app->connection, "seabolt/1.0.0a", auth_token);
+    BoltValue_destroy(auth_token);
     if (app->connection->status!=BOLT_READY) {
         fprintf(stderr, "FATAL: Failed to initialise connection\n");
         exit(EXIT_FAILURE);

--- a/seabolt-test/include/integration.hpp
+++ b/seabolt-test/include/integration.hpp
@@ -21,19 +21,21 @@
 #ifndef SEABOLT_TEST_INTEGRATION
 #define SEABOLT_TEST_INTEGRATION
 
-
 #include <cstring>
 #include <cstdlib>
 
 extern "C" {
-    #include "bolt/connections.h"
-    #include "bolt/logging.h"
-    #include "bolt/pooling.h"
-    #include "bolt/values.h"
+#include "bolt/auth.h"
+#include "bolt/connections.h"
+#include "bolt/logging.h"
+#include "bolt/pooling.h"
+#include "bolt/values.h"
 }
 
 #if USE_WINSOCK
+
 #include <winsock2.h>
+
 #endif
 
 #define SETTING(name, default_value) ((getenv(name) == nullptr) ? (default_value) : getenv(name))
@@ -47,23 +49,21 @@ extern "C" {
 
 #define VERBOSE() BoltLog_set_file(stderr)
 
-static const struct BoltUserProfile BOLT_PROFILE { BOLT_AUTH_BASIC, (char *)BOLT_USER, (char *)BOLT_PASSWORD, (char *)BOLT_USER_AGENT };
+static struct BoltAddress BOLT_IPV6_ADDRESS{(char*) BOLT_IPV6_HOST, (char*) BOLT_PORT};
 
-static struct BoltAddress BOLT_IPV6_ADDRESS { (char *)BOLT_IPV6_HOST, (char *)BOLT_PORT };
+static struct BoltAddress BOLT_IPV4_ADDRESS{(char*) BOLT_IPV4_HOST, (char*) BOLT_PORT};
 
-static struct BoltAddress BOLT_IPV4_ADDRESS { (char *)BOLT_IPV4_HOST, (char *)BOLT_PORT };
+struct BoltAddress* bolt_get_address(const char* host, const char* port);
 
-struct BoltAddress * bolt_get_address(const char * host, const char * port);
+struct BoltConnection* bolt_open_b(enum BoltTransport transport, const char* host, const char* port);
 
-struct BoltConnection * bolt_open_b(enum BoltTransport transport, const char * host, const char * port);
+struct BoltConnection* bolt_open_init_b(enum BoltTransport transport, const char* host, const char* port,
+        const char* user_agent, const struct BoltValue* auth_token);
 
-struct BoltConnection * bolt_open_init_b(enum BoltTransport transport, const char * host, const char * port,
-                                         const struct BoltUserProfile * profile);
+struct BoltConnection* bolt_open_init_default();
 
-void bolt_close_and_destroy_b(struct BoltConnection * connection);
+struct BoltValue* bolt_basic_auth(const char* username, const char* password);
 
-#define NEW_BOLT_CONNECTION() bolt_open_init_b(BOLT_SECURE_SOCKET, BOLT_IPV6_HOST, BOLT_PORT, &BOLT_PROFILE)
-
-
+void bolt_close_and_destroy_b(struct BoltConnection* connection);
 
 #endif // SEABOLT_TEST_INTEGRATION

--- a/seabolt-test/src/integration.cpp
+++ b/seabolt-test/src/integration.cpp
@@ -43,11 +43,19 @@ struct BoltConnection* bolt_open_b(enum BoltTransport transport, const char* hos
 }
 
 struct BoltConnection* bolt_open_init_b(enum BoltTransport transport, const char* host, const char* port,
-        const struct BoltUserProfile* profile)
+        const char* user_agent, const struct BoltValue* auth_token)
 {
     struct BoltConnection* connection = bolt_open_b(transport, host, port);
-    BoltConnection_init(connection, profile);
+    BoltConnection_init(connection, user_agent, auth_token);
     REQUIRE(connection->status==BOLT_READY);
+    return connection;
+}
+
+struct BoltConnection* bolt_open_init_default()
+{
+    struct BoltValue* auth_token = BoltAuth_basic(BOLT_USER, BOLT_PASSWORD, NULL);
+    struct BoltConnection* connection = bolt_open_init_b(BOLT_SECURE_SOCKET, BOLT_IPV6_HOST, BOLT_PORT, BOLT_USER_AGENT, auth_token);
+    BoltValue_destroy(auth_token);
     return connection;
 }
 

--- a/seabolt-test/src/test_pooling.cpp
+++ b/seabolt-test/src/test_pooling.cpp
@@ -24,8 +24,9 @@
 SCENARIO("Test using a pooled connection", "[integration][ipv6][secure][pooling]")
 {
     GIVEN("a new connection pool") {
+        const auto auth_token = BoltAuth_basic(BOLT_USER, BOLT_PASSWORD, NULL);
         struct BoltConnectionPool* pool = BoltConnectionPool_create(BOLT_SECURE_SOCKET, &BOLT_IPV6_ADDRESS,
-                &BOLT_PROFILE, 10);
+                BOLT_USER_AGENT, auth_token, 10);
         WHEN("a connection is acquired") {
             struct BoltConnection* connection = BoltConnectionPool_acquire(pool, "test");
             THEN("the connection should be connected") {
@@ -34,14 +35,16 @@ SCENARIO("Test using a pooled connection", "[integration][ipv6][secure][pooling]
             BoltConnectionPool_release(pool, connection);
         }
         BoltConnectionPool_destroy(pool);
+        BoltValue_destroy(auth_token);
     }
 }
 
 SCENARIO("Test reusing a pooled connection", "[integration][ipv6][secure][pooling]")
 {
     GIVEN("a new connection pool with one entry") {
+        const auto auth_token = BoltAuth_basic(BOLT_USER, BOLT_PASSWORD, NULL);
         struct BoltConnectionPool* pool = BoltConnectionPool_create(BOLT_SECURE_SOCKET, &BOLT_IPV6_ADDRESS,
-                &BOLT_PROFILE, 1);
+                BOLT_USER_AGENT, auth_token, 1);
         WHEN("a connection is acquired, released and acquired again") {
             struct BoltConnection* connection1 = BoltConnectionPool_acquire(pool, "test");
             BoltConnectionPool_release(pool, connection1);
@@ -55,14 +58,16 @@ SCENARIO("Test reusing a pooled connection", "[integration][ipv6][secure][poolin
             BoltConnectionPool_release(pool, connection2);
         }
         BoltConnectionPool_destroy(pool);
+        BoltValue_destroy(auth_token);
     }
 }
 
 SCENARIO("Test reusing a pooled connection that was abandoned", "[integration][ipv6][secure][pooling]")
 {
     GIVEN("a new connection pool with one entry") {
+        const auto auth_token = BoltAuth_basic(BOLT_USER, BOLT_PASSWORD, NULL);
         struct BoltConnectionPool* pool = BoltConnectionPool_create(BOLT_SECURE_SOCKET, &BOLT_IPV6_ADDRESS,
-                &BOLT_PROFILE, 1);
+                BOLT_USER_AGENT, auth_token, 1);
         WHEN("a connection is acquired, released and acquired again") {
             struct BoltConnection* connection1 = BoltConnectionPool_acquire(pool, "test");
             const char* cypher = "RETURN 1";
@@ -80,14 +85,16 @@ SCENARIO("Test reusing a pooled connection that was abandoned", "[integration][i
             BoltConnectionPool_release(pool, connection2);
         }
         BoltConnectionPool_destroy(pool);
+        BoltValue_destroy(auth_token);
     }
 }
 
 SCENARIO("Test running out of connections", "[integration][ipv6][secure][pooling]")
 {
     GIVEN("a new connection pool with one entry") {
+        const auto auth_token = BoltAuth_basic(BOLT_USER, BOLT_PASSWORD, NULL);
         struct BoltConnectionPool* pool = BoltConnectionPool_create(BOLT_SECURE_SOCKET, &BOLT_IPV6_ADDRESS,
-                &BOLT_PROFILE, 1);
+                BOLT_USER_AGENT, auth_token, 1);
         WHEN("two connections are acquired in turn") {
             struct BoltConnection* connection1 = BoltConnectionPool_acquire(pool, "test");
             struct BoltConnection* connection2 = BoltConnectionPool_acquire(pool, "test");
@@ -101,5 +108,6 @@ SCENARIO("Test running out of connections", "[integration][ipv6][secure][pooling
             BoltConnectionPool_release(pool, connection1);
         }
         BoltConnectionPool_destroy(pool);
+        BoltValue_destroy(auth_token);
     }
 }

--- a/seabolt-test/src/test_values.cpp
+++ b/seabolt-test/src/test_values.cpp
@@ -41,7 +41,7 @@
 SCENARIO("Test null parameter", "[integration][ipv6][secure]")
 {
     GIVEN("an open and initialised connection") {
-        struct BoltConnection* connection = NEW_BOLT_CONNECTION();
+        struct BoltConnection* connection = bolt_open_init_default();
         WHEN("successfully executed Cypher") {
             const char* cypher = "RETURN $x";
             BoltConnection_cypher(connection, cypher, strlen(cypher), 1);
@@ -62,7 +62,7 @@ SCENARIO("Test null parameter", "[integration][ipv6][secure]")
 SCENARIO("Test boolean in, boolean out", "[integration][ipv6][secure]")
 {
     GIVEN("an open and initialised connection") {
-        struct BoltConnection* connection = NEW_BOLT_CONNECTION();
+        struct BoltConnection* connection = bolt_open_init_default();
         WHEN("successfully executed Cypher") {
             const char* cypher = "RETURN $x";
             BoltConnection_cypher(connection, cypher, strlen(cypher), 1);
@@ -83,7 +83,7 @@ SCENARIO("Test boolean in, boolean out", "[integration][ipv6][secure]")
 SCENARIO("Test bytes in, bytes out", "[integration][ipv6][secure]")
 {
     GIVEN("an open and initialised connection") {
-        struct BoltConnection* connection = NEW_BOLT_CONNECTION();
+        struct BoltConnection* connection = bolt_open_init_default();
         WHEN("successfully executed Cypher") {
             const char* cypher = "RETURN $x";
             BoltConnection_cypher(connection, cypher, strlen(cypher), 1);
@@ -105,7 +105,7 @@ SCENARIO("Test bytes in, bytes out", "[integration][ipv6][secure]")
 SCENARIO("Test string in, string out", "[integration][ipv6][secure]")
 {
     GIVEN("an open and initialised connection") {
-        struct BoltConnection* connection = NEW_BOLT_CONNECTION();
+        struct BoltConnection* connection = bolt_open_init_default();
         WHEN("successfully executed Cypher") {
             const char* cypher = "RETURN $x";
             BoltConnection_cypher(connection, cypher, strlen(cypher), 1);
@@ -126,7 +126,7 @@ SCENARIO("Test string in, string out", "[integration][ipv6][secure]")
 SCENARIO("Test dictionary in, dictionary out", "[integration][ipv6][secure]")
 {
     GIVEN("an open and initialised connection") {
-        struct BoltConnection* connection = NEW_BOLT_CONNECTION();
+        struct BoltConnection* connection = bolt_open_init_default();
         WHEN("successfully executed Cypher") {
             const char* cypher = "RETURN $x";
             BoltConnection_cypher(connection, cypher, strlen(cypher), 1);
@@ -167,7 +167,7 @@ SCENARIO("Test dictionary in, dictionary out", "[integration][ipv6][secure]")
 SCENARIO("Test integer in, integer out", "[integration][ipv6][secure]")
 {
     GIVEN("an open and initialised connection") {
-        struct BoltConnection* connection = NEW_BOLT_CONNECTION();
+        struct BoltConnection* connection = bolt_open_init_default();
         WHEN("successfully executed Cypher") {
             const char* cypher = "RETURN $x";
             BoltConnection_cypher(connection, cypher, strlen(cypher), 1);
@@ -188,7 +188,7 @@ SCENARIO("Test integer in, integer out", "[integration][ipv6][secure]")
 SCENARIO("Test float in, float out", "[integration][ipv6][secure]")
 {
     GIVEN("an open and initialised connection") {
-        struct BoltConnection* connection = NEW_BOLT_CONNECTION();
+        struct BoltConnection* connection = bolt_open_init_default();
         WHEN("successfully executed Cypher") {
             const char* cypher = "RETURN $x";
             BoltConnection_cypher(connection, cypher, strlen(cypher), 1);
@@ -209,7 +209,7 @@ SCENARIO("Test float in, float out", "[integration][ipv6][secure]")
 SCENARIO("Test structure in result", "[integration][ipv6][secure]")
 {
     GIVEN("an open and initialised connection") {
-        struct BoltConnection* connection = NEW_BOLT_CONNECTION();
+        struct BoltConnection* connection = bolt_open_init_default();
         WHEN("successfully executed Cypher") {
             BoltConnection_load_begin_request(connection);
             const char* cypher = "CREATE (a:Person {name:'Alice'}) RETURN a";

--- a/seabolt/include/bolt/auth.h
+++ b/seabolt/include/bolt/auth.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#ifndef SEABOLT_AUTH
+#define SEABOLT_AUTH
+
+#include "config.h"
+#include "values.h"
+
+
+PUBLIC struct BoltValue* BoltAuth_basic(const char* username, const char* password, const char* realm);
+
+#endif // SEABOLT_AUTH

--- a/seabolt/include/bolt/auth.h
+++ b/seabolt/include/bolt/auth.h
@@ -24,7 +24,6 @@
 #include "config.h"
 #include "values.h"
 
-
 PUBLIC struct BoltValue* BoltAuth_basic(const char* username, const char* password, const char* realm);
 
 #endif // SEABOLT_AUTH

--- a/seabolt/include/bolt/config-impl.h
+++ b/seabolt/include/bolt/config-impl.h
@@ -34,6 +34,7 @@
 #include <time.h>
 
 #if USE_POSIXSOCK
+#include <unistd.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
 #include <netinet/tcp.h>

--- a/seabolt/include/bolt/pooling.h
+++ b/seabolt/include/bolt/pooling.h
@@ -30,26 +30,25 @@
 /**
  * Connection pool (experimental)
  */
-struct BoltConnectionPool
-{
+struct BoltConnectionPool {
     mutex_t mutex;
     enum BoltTransport transport;
-    struct BoltAddress * address;
-    struct BoltUserProfile * profile;
+    struct BoltAddress* address;
+    char* user_agent;
+    struct BoltValue* auth_token;
     size_t size;
-    struct BoltConnection * connections;
+    struct BoltConnection* connections;
 };
 
-
 PUBLIC
-struct BoltConnectionPool *
-BoltConnectionPool_create(enum BoltTransport transport, struct BoltAddress * address, const struct BoltUserProfile * profile, size_t size);
+struct BoltConnectionPool*
+BoltConnectionPool_create(enum BoltTransport transport, struct BoltAddress* address,
+        const char* user_agent, const struct BoltValue* auth_token, size_t size);
 
-PUBLIC void BoltConnectionPool_destroy(struct BoltConnectionPool * pool);
+PUBLIC void BoltConnectionPool_destroy(struct BoltConnectionPool* pool);
 
-PUBLIC struct BoltConnection * BoltConnectionPool_acquire(struct BoltConnectionPool * pool, const void * agent);
+PUBLIC struct BoltConnection* BoltConnectionPool_acquire(struct BoltConnectionPool* pool, const void* agent);
 
-PUBLIC int BoltConnectionPool_release(struct BoltConnectionPool * pool, struct BoltConnection * connection);
-
+PUBLIC int BoltConnectionPool_release(struct BoltConnectionPool* pool, struct BoltConnection* connection);
 
 #endif //SEABOLT_POOLING_H

--- a/seabolt/include/bolt/values.h
+++ b/seabolt/include/bolt/values.h
@@ -30,7 +30,7 @@
 
 #include "config.h"
 
-#if CHAR_BIT != 8
+#if CHAR_BIT!=8
 #error "Cannot compile if `char` is not 8-bit"
 #endif
 
@@ -49,20 +49,16 @@ static const char HEX_DIGITS[] = {'0', '1', '2', '3', '4', '5', '6', '7',
 
 #define hex0(mem, offset) HEX_DIGITS[(mem)[offset] & 0x0F]
 
-
 #define sizeof_n(type, n) (size_t)((n) >= 0 ? sizeof(type) * (n) : 0)
 
-
 #define to_bit(x) (char)((x) == 0 ? 0 : 1);
-
 
 struct BoltValue;
 
 /**
  * Enumeration of the types available in the Bolt type system.
  */
-enum BoltType
-{
+enum BoltType {
     BOLT_NULL = 0,
     BOLT_BOOLEAN = 1,
     BOLT_INTEGER = 2,
@@ -77,11 +73,10 @@ enum BoltType
 /**
  * For holding extended values that exceed the size of a single BoltValue.
  */
-union BoltExtendedValue
-{
-    void * as_ptr;
-    char * as_char;
-    struct BoltValue * as_value;
+union BoltExtendedValue {
+    void* as_ptr;
+    char* as_char;
+    struct BoltValue* as_value;
 };
 
 /**
@@ -98,8 +93,7 @@ union BoltExtendedValue
  * +----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+
  * ```
  */
-struct BoltValue
-{
+struct BoltValue {
     /// Type of this value, as defined in BoltType.
     int16_t type;
 
@@ -118,8 +112,7 @@ struct BoltValue
 
     /// Data content of the value, or a pointer to
     /// extended content.
-    union
-    {
+    union {
         char as_char[16];
         uint32_t as_uint32[4];
         int8_t as_int8[16];
@@ -149,12 +142,29 @@ PUBLIC struct BoltValue* BoltValue_create();
 PUBLIC void BoltValue_destroy(struct BoltValue* value);
 
 /**
+ * Duplicates a BoltValue instance
+ *
+ * @param value
+ * @return
+ */
+PUBLIC struct BoltValue* BoltValue_duplicate(const struct BoltValue* value);
+
+/**
+ * Deep copy a BoltValue instance to another one
+ *
+ * @param src
+ * @param dest
+ * @return
+ */
+PUBLIC void BoltValue_copy(struct BoltValue* dest, const struct BoltValue *src);
+
+/**
  * Return the type of a BoltValue.
  *
  * @param value
  * @return
  */
-PUBLIC enum BoltType BoltValue_type(const struct BoltValue * value);
+PUBLIC enum BoltType BoltValue_type(const struct BoltValue* value);
 
 /**
  * Write a textual representation of a BoltValue to a FILE.
@@ -164,7 +174,7 @@ PUBLIC enum BoltType BoltValue_type(const struct BoltValue * value);
  * @param protocol_version
  * @return
  */
-PUBLIC int BoltValue_write(struct BoltValue * value, FILE * file, int32_t protocol_version);
+PUBLIC int BoltValue_write(struct BoltValue* value, FILE* file, int32_t protocol_version);
 
 
 
@@ -173,49 +183,42 @@ PUBLIC int BoltValue_write(struct BoltValue * value, FILE * file, int32_t protoc
  *
  * @param value
  */
-PUBLIC void BoltValue_format_as_Null(struct BoltValue * value);
+PUBLIC void BoltValue_format_as_Null(struct BoltValue* value);
 
+PUBLIC void BoltValue_format_as_Boolean(struct BoltValue* value, char data);
 
+PUBLIC char BoltBoolean_get(const struct BoltValue* value);
 
-PUBLIC void BoltValue_format_as_Boolean(struct BoltValue * value, char data);
+PUBLIC void BoltValue_format_as_Integer(struct BoltValue* value, int64_t data);
 
-PUBLIC char BoltBoolean_get(const struct BoltValue * value);
+PUBLIC int64_t BoltInteger_get(const struct BoltValue* value);
 
+PUBLIC void BoltValue_format_as_Float(struct BoltValue* value, double data);
 
+PUBLIC double BoltFloat_get(const struct BoltValue* value);
 
-PUBLIC void BoltValue_format_as_Integer(struct BoltValue * value, int64_t data);
+PUBLIC void BoltValue_format_as_String(struct BoltValue* value, const char* data, int32_t length);
 
-PUBLIC int64_t BoltInteger_get(const struct BoltValue * value);
+PUBLIC char* BoltString_get(const struct BoltValue* value);
 
+PUBLIC int BoltString_equals(struct BoltValue* value, const char* data);
 
+PUBLIC void BoltValue_format_as_Dictionary(struct BoltValue* value, int32_t length);
 
-PUBLIC void BoltValue_format_as_Float(struct BoltValue * value, double data);
+PUBLIC struct BoltValue* BoltDictionary_key(const struct BoltValue* value, int32_t index);
 
-PUBLIC double BoltFloat_get(const struct BoltValue * value);
+PUBLIC const char* BoltDictionary_get_key(const struct BoltValue* value, int32_t index);
 
+PUBLIC int32_t BoltDictionary_get_key_size(const struct BoltValue* value, int32_t index);
 
+PUBLIC int32_t
+BoltDictionary_get_key_index(const struct BoltValue* value, const char* key, size_t key_size, int32_t start_index);
 
-PUBLIC void BoltValue_format_as_String(struct BoltValue * value, const char * data, int32_t length);
+PUBLIC int BoltDictionary_set_key(struct BoltValue* value, int32_t index, const char* key, size_t key_size);
 
-PUBLIC char* BoltString_get(struct BoltValue * value);
+PUBLIC struct BoltValue* BoltDictionary_value(const struct BoltValue* value, int32_t index);
 
-PUBLIC int BoltString_equals(struct BoltValue * value, const char * data);
-
-PUBLIC void BoltValue_format_as_Dictionary(struct BoltValue * value, int32_t length);
-
-PUBLIC struct BoltValue * BoltDictionary_key(struct BoltValue * value, int32_t index);
-
-PUBLIC const char * BoltDictionary_get_key(struct BoltValue * value, int32_t index);
-
-PUBLIC int32_t BoltDictionary_get_key_size(struct BoltValue * value, int32_t index);
-
-PUBLIC int32_t BoltDictionary_get_key_index(struct BoltValue * value, const char * key, size_t key_size, int32_t start_index);
-
-PUBLIC int BoltDictionary_set_key(struct BoltValue * value, int32_t index, const char * key, size_t key_size);
-
-PUBLIC struct BoltValue * BoltDictionary_value(struct BoltValue * value, int32_t index);
-
-PUBLIC struct BoltValue * BoltDictionary_value_by_key(struct BoltValue * value, const char * key, size_t key_size);
+PUBLIC struct BoltValue* BoltDictionary_value_by_key(const struct BoltValue* value, const char* key, size_t key_size);
 
 
 /**
@@ -224,28 +227,22 @@ PUBLIC struct BoltValue * BoltDictionary_value_by_key(struct BoltValue * value, 
  * @param value
  * @param length
  */
-PUBLIC void BoltValue_format_as_List(struct BoltValue * value, int32_t length);
+PUBLIC void BoltValue_format_as_List(struct BoltValue* value, int32_t length);
 
 PUBLIC void BoltList_resize(struct BoltValue* value, int32_t size);
 
-PUBLIC struct BoltValue * BoltList_value(const struct BoltValue* value, int32_t index);
+PUBLIC struct BoltValue* BoltList_value(const struct BoltValue* value, int32_t index);
 
+PUBLIC void BoltValue_format_as_Bytes(struct BoltValue* value, char* data, int32_t length);
 
+PUBLIC char BoltBytes_get(const struct BoltValue* value, int32_t index);
 
-PUBLIC void BoltValue_format_as_Bytes(struct BoltValue * value, char * data, int32_t length);
+PUBLIC char* BoltBytes_get_all(const struct BoltValue* value);
 
-PUBLIC char BoltBytes_get(const struct BoltValue * value, int32_t index);
-
-PUBLIC char * BoltBytes_get_all(struct BoltValue * value);
-
-
-
-PUBLIC void BoltValue_format_as_Structure(struct BoltValue * value, int16_t code, int32_t length);
+PUBLIC void BoltValue_format_as_Structure(struct BoltValue* value, int16_t code, int32_t length);
 
 PUBLIC int16_t BoltStructure_code(const struct BoltValue* value);
 
-PUBLIC struct BoltValue * BoltStructure_value(const struct BoltValue* value, int32_t index);
-
-
+PUBLIC struct BoltValue* BoltStructure_value(const struct BoltValue* value, int32_t index);
 
 #endif // SEABOLT_VALUES

--- a/seabolt/src/bolt/auth.c
+++ b/seabolt/src/bolt/auth.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include <string.h>
+
+#include "bolt/auth.h"
+
+struct BoltValue* BoltAuth_basic(const char* username, const char* password, const char* realm)
+{
+    struct BoltValue* auth_token = BoltValue_create();
+    BoltValue_format_as_Dictionary(auth_token, realm==NULL ? 3 : 4);
+    BoltDictionary_set_key(auth_token, 0, "scheme", 6);
+    BoltValue_format_as_String(BoltDictionary_value(auth_token, 0), "basic", 5);
+    BoltDictionary_set_key(auth_token, 1, "principal", 9);
+    BoltValue_format_as_String(BoltDictionary_value(auth_token, 1), username, (int32_t) strlen(username));
+    BoltDictionary_set_key(auth_token, 2, "credentials", 11);
+    BoltValue_format_as_String(BoltDictionary_value(auth_token, 2), password, (int32_t) strlen(password));
+    if (realm!=NULL) {
+        BoltDictionary_set_key(auth_token, 3, "realm", 5);
+        BoltValue_format_as_String(BoltDictionary_value(auth_token, 3), realm, (int32_t) strlen(realm));
+    }
+    return auth_token;
+
+}

--- a/seabolt/src/bolt/connections.c
+++ b/seabolt/src/bolt/connections.c
@@ -39,7 +39,7 @@
 #define RECEIVE(socket, buffer, size, flags) (int)(recv(socket, buffer, (size_t)(size), flags))
 #define RECEIVE_S(socket, buffer, size, flags) SSL_read(socket, buffer, size)
 #define ADDR_SIZE(address) address->ss_family == AF_INET ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6)
-#ifdef USE_WINSOCK
+#if USE_WINSOCK
 #define SETSOCKETOPT(socket, level, optname, optval, optlen) setsockopt(socket, level, optname, (const char *)(optval), optlen)
 #define CLOSE(socket) closesocket(socket)
 #else
@@ -86,7 +86,7 @@ enum BoltConnectionError _last_error()
         return BOLT_UNKNOWN_ERROR;
     }
 #else
-    int error_code = WSAGetLastError();
+    int error_code = errno;
     BoltLog_error("bolt: socket error code: %d", error_code);
     switch (error_code)
     {

--- a/seabolt/src/bolt/protocol/v1.h
+++ b/seabolt/src/bolt/protocol/v1.h
@@ -101,7 +101,7 @@ int BoltProtocolV1_load_message(struct BoltConnection* connection, struct BoltMe
 
 int BoltProtocolV1_load_message_quietly(struct BoltConnection* connection, struct BoltMessage* message);
 
-int BoltProtocolV1_compile_INIT(struct BoltMessage* message, const struct BoltUserProfile* profile);
+int BoltProtocolV1_compile_INIT(struct BoltMessage* message, const char* user_agent, const struct BoltValue* auth_token);
 
 int BoltProtocolV1_fetch(struct BoltConnection* connection, bolt_request_t request_id);
 
@@ -120,7 +120,7 @@ const char* BoltProtocolV1_structure_name(int16_t code);
 
 const char* BoltProtocolV1_message_name(int16_t code);
 
-int BoltProtocolV1_init(struct BoltConnection* connection, const struct BoltUserProfile* profile);
+int BoltProtocolV1_init(struct BoltConnection* connection, const char* user_agent, const struct BoltValue* auth_token);
 
 int BoltProtocolV1_reset(struct BoltConnection* connection);
 

--- a/seabolt/src/bolt/protocol/v1.h
+++ b/seabolt/src/bolt/protocol/v1.h
@@ -101,7 +101,8 @@ int BoltProtocolV1_load_message(struct BoltConnection* connection, struct BoltMe
 
 int BoltProtocolV1_load_message_quietly(struct BoltConnection* connection, struct BoltMessage* message);
 
-int BoltProtocolV1_compile_INIT(struct BoltMessage* message, const char* user_agent, const struct BoltValue* auth_token);
+int BoltProtocolV1_compile_INIT(struct BoltMessage* message, const char* user_agent, const struct BoltValue* auth_token,
+        int mask_secure_fields);
 
 int BoltProtocolV1_fetch(struct BoltConnection* connection, bolt_request_t request_id);
 


### PR DESCRIPTION
This PR changes how authentication tokens are provided to the connector. Previously, there was a dedicated struct to hold basic authentication data, but since it is not flexible enough to cover other possible authentication schemes (none, kerberos, custom), this PR removes previously defined `struct BoltUserProfile` and expects authentication token to be passed as a `BoltValue`.

With this change, it is now possible for driver implementations to pass token information via bolt defined values (i.e. bolt dictionary that holds related key-value pairs) and `user_agent` is now an explicit parameter.

Besides, there's now a `BoltConnection_last_bookmark` method to retrieve the latest bookmark data received from the server.