### PR TITLE
Export graph type codes and add pkg-config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This project requires the following tools/libraries to be installed in order to 
 2. Install XCode Command Line Tools via `xcode-select --install`
 3. Install CMake `brew install cmake`
 4. Install OpenSSL `brew install openssl`
+5. Create an environment variable named `OPENSSL_LIB_ROOT` that points to the openssl library installation path (default is `/usr/local/opt/openssl`)
 
 ### Windows
 
@@ -30,7 +31,8 @@ Currently windows builds also depend on OpenSSL, however support for windows sec
 1. Install Visual Studio 2017 with VC++ support,
 2. Install CMake via `choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System'`
 3. Install OpenSSL Win32 using `https://slproweb.com/download/Win32OpenSSL-1_1_0g.exe` 
-4. Install OpenSSL Win64 using `https://slproweb.com/download/Win64OpenSSL-1_1_0g.exe` 
+4. Install OpenSSL Win64 using `https://slproweb.com/download/Win64OpenSSL-1_1_0g.exe`
+5. Create an environment variable named `OPENSSL_LIB_ROOT` that points to the openssl library installation path (default is `C:/OpenSSL-Win64`).
 
 ## Building
 
@@ -39,6 +41,11 @@ Currently windows builds also depend on OpenSSL, however support for windows sec
 To build the project, run either the `make_debug.sh` or the `make_release.sh` script from the project root directory.
 This will compile and deposit project artifacts in the `build/bin` and `build/lib` directories.
 To create distributable packages, use `make_packages.sh` instead.
+
+### Windows
+
+To build the project, run either the `make_debug.cmd` or the `make_release.cmd` script from the project root directory.
+This will compile and deposit project artifacts in the `build/bin` and `build/lib` directories.
 
 ## Docs 
 
@@ -57,9 +64,11 @@ $ pip install --user sphinx breathe
 
 ## Running
 
+### Linux / MacOS X
+
 To run a query, use the following...
 ```
-BOLT_PASSWORD=password build/bin/seabolt "UNWIND range(1, 1000000) AS n RETURN n"
+BOLT_PASSWORD=password build/bin/bolt "UNWIND range(1, 1000000) AS n RETURN n"
 ```
 
 By default, this will simply display stats for the query execution.
@@ -71,4 +80,23 @@ BOLT_PORT=7687
 BOLT_USER=neo4j
 BOLT_PASSWORD=password
 BOLT_LOG=0|1|2
+```
+
+### Windows (Powershell)
+
+To run a query, use the following...
+```
+$env:BOLT_PASSWORD=password
+build/bin/bolt.exe "UNWIND range(1, 1000000) AS n RETURN n"
+```
+
+By default, this will simply display stats for the query execution.
+The following environment variables can be used:
+```
+$env:BOLT_SECURE=0|1
+$env:BOLT_HOST=<host name, IPv4 or IPv6 address>
+$env:BOLT_PORT=7687
+$env:BOLT_USER=neo4j
+$env:BOLT_PASSWORD=password
+$env:BOLT_LOG=0|1|2
 ```

--- a/seabolt/CMakeLists.txt
+++ b/seabolt/CMakeLists.txt
@@ -53,7 +53,6 @@ configure_file (
   "${PROJECT_SOURCE_DIR}/include/bolt/config-options.h"
   )
 
-
 file(GLOB H_FILES include/bolt/*.h)
 file(GLOB C_FILES src/bolt/*.c src/bolt/**/*.c)
 add_library(${PROJECT_NAME} SHARED ${H_FILES} ${C_FILES})
@@ -66,10 +65,12 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
 
 if ( ${WINSOCK} )
 	target_link_libraries(${PROJECT_NAME} "ws2_32.lib")
+	set(PRIVATE_LIBS "${PRIVATE_LIBS} -lws2_32")
 endif ()
 
 if ( ${WINSSPI} )
 	target_link_libraries(${PROJECT_NAME} "fwpuclnt.lib")
+	set(PRIVATE_LIBS "${PRIVATE_LIBS} -lfwpuclnt")
 endif ()
 
 if ( ${OPENSSL} )
@@ -87,14 +88,24 @@ if ( ${OPENSSL} )
 
 	target_include_directories(${PROJECT_NAME} PRIVATE ${OPENSSL_INCLUDE_DIRS})
 	target_link_libraries(${PROJECT_NAME} ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY})
+	set(PRIVATE_LIBS "${PRIVATE_LIBS} -lssl -lcrypto")
 endif ()
 
 if ( ${PTHREAD} )
 	target_link_libraries(${PROJECT_NAME} "pthread")
+	set(PRIVATE_LIBS "${PRIVATE_LIBS} -lpthread")
 endif ()
 
 set(${PROJECT_NAME}_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/include
         CACHE INTERNAL "${PROJECT_NAME}: Include Directories" FORCE)
+
+set(DEST_DIR "${CMAKE_SOURCE_DIR}")
+# configure pkg-config file
+configure_file(
+		"${PROJECT_SOURCE_DIR}/seabolt-dev.pc.in"
+		"${CMAKE_CURRENT_SOURCE_DIR}/../build/seabolt.pc"
+		@ONLY
+)
 
 # build a CPack driven installer package
 include (InstallRequiredSystemLibraries)
@@ -111,3 +122,4 @@ include (CPack)
 
 install(TARGETS ${PROJECT_NAME} DESTINATION lib)
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/bolt" DESTINATION include FILES_MATCHING PATTERN "*.h")
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../build/lib/pkgconfig" DESTINATION lib)

--- a/seabolt/include/bolt/values.h
+++ b/seabolt/include/bolt/values.h
@@ -53,6 +53,11 @@ static const char HEX_DIGITS[] = {'0', '1', '2', '3', '4', '5', '6', '7',
 
 #define to_bit(x) (char)((x) == 0 ? 0 : 1);
 
+#define BOLT_VALUE_TYPE_NODE 0x4E
+#define BOLT_VALUE_TYPE_RELATIONSHIP 0x52
+#define BOLT_VALUE_TYPE_UNBOUND_RELATIONSHIP 0x72
+#define BOLT_VALUE_TYPE_PATH 0x50
+
 struct BoltValue;
 
 /**

--- a/seabolt/seabolt-dev.pc.in
+++ b/seabolt/seabolt-dev.pc.in
@@ -1,0 +1,12 @@
+prefix=@DEST_DIR@
+exec_prefix=${prefix}/build/bin
+libdir=${prefix}/build/lib
+includedir=${prefix}/seabolt/include
+
+Name: seabolt
+Description: Neo4j Bolt Connector Library for C.
+Version: 0.1
+
+Requires:
+Libs: -L${libdir} -lseabolt @PRIVATE_LIBS@
+Cflags: -I${includedir}


### PR DESCRIPTION
This PR exports graph type codes to be used by consuming libraries to enable reading node, relationship and path values from `BoltStructure` instances.

It also adds generation of `seabolt.pc` file to the `CMakeLists.txt` so that `neo4j-go-connector` can be built with correct compilation and linking flags with the help of `pkg-config` tool.