### PR TITLE
Fix buffer overwrite issue when receiving data requires looping

### DIFF
--- a/seabolt/src/bolt/connections.c
+++ b/seabolt/src/bolt/connections.c
@@ -324,10 +324,10 @@ int _receive(struct BoltConnection* connection, char* buffer, int min_size, int 
         int received = 0;
         switch (connection->transport) {
         case BOLT_SOCKET:
-            received = RECEIVE(connection->socket, buffer, max_remaining, 0);
+            received = RECEIVE(connection->socket, buffer + total_received, max_remaining, 0);
             break;
         case BOLT_SECURE_SOCKET:
-            received = RECEIVE_S(connection->ssl, buffer, max_remaining, 0);
+            received = RECEIVE_S(connection->ssl, buffer + total_received, max_remaining, 0);
             break;
         }
         if (received>0) {


### PR DESCRIPTION
When receive is called on a socket, we're looping to get all of the data we're waiting. Where most of the time a single receive call is enough, especially with large data it requires looping.

This PR fixes overwriting previously read and not processed data when receive is called more than once in a single loop.