### PR TITLE
Add support for Bolt V3

### DIFF
--- a/seabolt-cli/src/main.c
+++ b/seabolt-cli/src/main.c
@@ -242,7 +242,7 @@ int app_debug(struct Application* app, const char* cypher)
     BoltUtil_get_time(&t[2]);    // Checkpoint 2 - after handshake and initialisation
 
     //BoltConnection_load_bookmark(bolt->connection, "tx:1234");
-    BoltConnection_load_begin_tx_request(app->connection);
+    BoltConnection_load_begin_request(app->connection);
     BoltConnection_set_run_cypher(app->connection, cypher, strlen(cypher), 0);
     BoltConnection_load_run_request(app->connection);
     bolt_request run = BoltConnection_last_request(app->connection);
@@ -354,7 +354,7 @@ long run_fetch(const struct Application* app, const char* cypher)
 {
     long record_count = 0;
     //BoltConnection_load_bookmark(bolt->connection, "tx:1234");
-    BoltConnection_load_begin_tx_request(app->connection);
+    BoltConnection_load_begin_request(app->connection);
     BoltConnection_set_run_cypher(app->connection, cypher, strlen(cypher), 0);
     BoltConnection_load_run_request(app->connection);
     bolt_request run = BoltConnection_last_request(app->connection);

--- a/seabolt-cli/src/main.c
+++ b/seabolt-cli/src/main.c
@@ -218,6 +218,7 @@ void app_connect(struct Application* app)
     struct BoltConnectionResult result = BoltConnector_acquire(app->connector, app->access_mode);
     if (result.connection==NULL) {
         fprintf(stderr, "FATAL: Failed to connect\n");
+        app_destroy(app);
         exit(EXIT_FAILURE);
     }
     app->connection = result.connection;

--- a/seabolt-integration-test/src/test_chunking_v1.cpp
+++ b/seabolt-integration-test/src/test_chunking_v1.cpp
@@ -38,7 +38,7 @@ using Catch::Matchers::Equals;
     BoltConnection_load_run_request(connection);\
     BoltConnection_load_pull_request(connection, -1);\
     BoltConnection_send(connection);\
-    bolt_request_t (result) = BoltConnection_last_request(connection);
+    bolt_request (result) = BoltConnection_last_request(connection);
 
 SCENARIO("Test chunking", "[integration][ipv6][secure]")
 {
@@ -46,8 +46,8 @@ SCENARIO("Test chunking", "[integration][ipv6][secure]")
         struct BoltConnection* connection = bolt_open_init_default();
         WHEN("Cypher with parameter of small size") {
             const char* cypher = "RETURN $x";
-            BoltConnection_cypher(connection, cypher, strlen(cypher), 1);
-            BoltValue* x = BoltConnection_cypher_parameter(connection, 0, "x", 1);
+            BoltConnection_set_run_cypher(connection, cypher, strlen(cypher), 1);
+            BoltValue* x = BoltConnection_set_run_cypher_parameter(connection, 0, "x", 1);
             int param_size = 2;
             char* param = (char*) calloc(param_size, sizeof(char));
             for (int i = 1; i<param_size; i++) {
@@ -57,7 +57,7 @@ SCENARIO("Test chunking", "[integration][ipv6][secure]")
             RUN_PULL_SEND(connection, result);
             THEN("It should return passed parameter") {
                 while (BoltConnection_fetch(connection, result)) {
-                    const struct BoltValue* field_values = BoltConnection_record_fields(connection);
+                    const struct BoltValue* field_values = BoltConnection_field_values(connection);
                     struct BoltValue* value = BoltList_value(field_values, 0);
                     REQUIRE_BOLT_STRING(value, param, strlen(param));
                 }
@@ -67,8 +67,8 @@ SCENARIO("Test chunking", "[integration][ipv6][secure]")
 
         WHEN("Cypher with parameter of medium size") {
             const char* cypher = "RETURN $x";
-            BoltConnection_cypher(connection, cypher, strlen(cypher), 1);
-            BoltValue* x = BoltConnection_cypher_parameter(connection, 0, "x", 1);
+            BoltConnection_set_run_cypher(connection, cypher, strlen(cypher), 1);
+            BoltValue* x = BoltConnection_set_run_cypher_parameter(connection, 0, "x", 1);
             int param_size = 32769;
             char* param = (char*) calloc(param_size, sizeof(char));
             for (int i = 1; i<param_size; i++) {
@@ -78,7 +78,7 @@ SCENARIO("Test chunking", "[integration][ipv6][secure]")
             RUN_PULL_SEND(connection, result);
             THEN("It should return passed parameter") {
                 while (BoltConnection_fetch(connection, result)) {
-                    const struct BoltValue* field_values = BoltConnection_record_fields(connection);
+                    const struct BoltValue* field_values = BoltConnection_field_values(connection);
                     struct BoltValue* value = BoltList_value(field_values, 0);
                     REQUIRE_BOLT_STRING(value, param, strlen(param));
                 }
@@ -88,8 +88,8 @@ SCENARIO("Test chunking", "[integration][ipv6][secure]")
 
         WHEN("Cypher with parameter of boundary size") {
             const char* cypher = "RETURN $x";
-            BoltConnection_cypher(connection, cypher, strlen(cypher), 1);
-            BoltValue* x = BoltConnection_cypher_parameter(connection, 0, "x", 1);
+            BoltConnection_set_run_cypher(connection, cypher, strlen(cypher), 1);
+            BoltValue* x = BoltConnection_set_run_cypher_parameter(connection, 0, "x", 1);
             int param_size = 65536;
             char* param = (char*) calloc(param_size, sizeof(char));
             for (int i = 1; i<param_size; i++) {
@@ -99,7 +99,7 @@ SCENARIO("Test chunking", "[integration][ipv6][secure]")
             RUN_PULL_SEND(connection, result);
             THEN("It should return passed parameter") {
                 while (BoltConnection_fetch(connection, result)) {
-                    const struct BoltValue* field_values = BoltConnection_record_fields(connection);
+                    const struct BoltValue* field_values = BoltConnection_field_values(connection);
                     struct BoltValue* value = BoltList_value(field_values, 0);
                     REQUIRE_BOLT_STRING(value, param, strlen(param));
                 }
@@ -109,8 +109,8 @@ SCENARIO("Test chunking", "[integration][ipv6][secure]")
 
         WHEN("Cypher with parameter of large size") {
             const char* cypher = "RETURN $x";
-            BoltConnection_cypher(connection, cypher, strlen(cypher), 1);
-            BoltValue* x = BoltConnection_cypher_parameter(connection, 0, "x", 1);
+            BoltConnection_set_run_cypher(connection, cypher, strlen(cypher), 1);
+            BoltValue* x = BoltConnection_set_run_cypher_parameter(connection, 0, "x", 1);
             int param_size = 65535*2+1;
             char* param = (char*) calloc(param_size, sizeof(char));
             for (int i = 1; i<param_size; i++) {
@@ -120,7 +120,7 @@ SCENARIO("Test chunking", "[integration][ipv6][secure]")
             RUN_PULL_SEND(connection, result);
             THEN("It should return passed parameter") {
                 while (BoltConnection_fetch(connection, result)) {
-                    const struct BoltValue* field_values = BoltConnection_record_fields(connection);
+                    const struct BoltValue* field_values = BoltConnection_field_values(connection);
                     struct BoltValue* value = BoltList_value(field_values, 0);
                     REQUIRE_BOLT_STRING(value, param, strlen(param));
                 }
@@ -130,8 +130,8 @@ SCENARIO("Test chunking", "[integration][ipv6][secure]")
 
         WHEN("Cypher with parameter of very large size") {
             const char* cypher = "RETURN $x";
-            BoltConnection_cypher(connection, cypher, strlen(cypher), 1);
-            BoltValue* x = BoltConnection_cypher_parameter(connection, 0, "x", 1);
+            BoltConnection_set_run_cypher(connection, cypher, strlen(cypher), 1);
+            BoltValue* x = BoltConnection_set_run_cypher_parameter(connection, 0, "x", 1);
             int param_size = 65535*10+1;
             char* param = (char*) calloc(param_size, sizeof(char));
             for (int i = 1; i<param_size; i++) {
@@ -141,7 +141,7 @@ SCENARIO("Test chunking", "[integration][ipv6][secure]")
             RUN_PULL_SEND(connection, result);
             THEN("It should return passed parameter") {
                 while (BoltConnection_fetch(connection, result)) {
-                    const struct BoltValue* field_values = BoltConnection_record_fields(connection);
+                    const struct BoltValue* field_values = BoltConnection_field_values(connection);
                     struct BoltValue* value = BoltList_value(field_values, 0);
                     REQUIRE_BOLT_STRING(value, param, strlen(param));
                 }

--- a/seabolt-integration-test/src/test_direct.cpp
+++ b/seabolt-integration-test/src/test_direct.cpp
@@ -220,11 +220,11 @@ SCENARIO("Test execution of simple Cypher statement", "[integration][ipv6][secur
         struct BoltConnection* connection = bolt_open_init_default();
         WHEN("successfully executed Cypher") {
             const char* cypher = "RETURN 1";
-            BoltConnection_cypher(connection, cypher, strlen(cypher), 0);
+            BoltConnection_set_run_cypher(connection, cypher, strlen(cypher), 0);
             BoltConnection_load_run_request(connection);
-            bolt_request_t run = BoltConnection_last_request(connection);
+            bolt_request run = BoltConnection_last_request(connection);
             BoltConnection_load_pull_request(connection, -1);
-            bolt_request_t pull = BoltConnection_last_request(connection);
+            bolt_request pull = BoltConnection_last_request(connection);
             BoltConnection_send(connection);
             int records = BoltConnection_fetch_summary(connection, run);
             REQUIRE(records==0);
@@ -241,14 +241,14 @@ SCENARIO("Test field names returned from Cypher execution", "[integration][ipv6]
         struct BoltConnection* connection = bolt_open_init_default();
         WHEN("successfully executed Cypher") {
             const char* cypher = "RETURN 1 AS first, true AS second, 3.14 AS third";
-            BoltConnection_cypher(connection, cypher, strlen(cypher), 0);
+            BoltConnection_set_run_cypher(connection, cypher, strlen(cypher), 0);
             BoltConnection_load_run_request(connection);
-            bolt_request_t run = BoltConnection_last_request(connection);
+            bolt_request run = BoltConnection_last_request(connection);
             BoltConnection_load_pull_request(connection, -1);
             BoltConnection_send(connection);
-            bolt_request_t last = BoltConnection_last_request(connection);
+            bolt_request last = BoltConnection_last_request(connection);
             BoltConnection_fetch_summary(connection, run);
-            const struct BoltValue* fields = BoltConnection_fields(connection);
+            const struct BoltValue* fields = BoltConnection_field_names(connection);
             REQUIRE(fields->size==3);
             struct BoltValue* field_name_value = BoltList_value(fields, 0);
             const char* field_name = BoltString_get(field_name_value);
@@ -275,19 +275,19 @@ SCENARIO("Test parameterised Cypher statements", "[integration][ipv6][secure]")
         struct BoltConnection* connection = bolt_open_init_default();
         WHEN("successfully executed Cypher") {
             const char* cypher = "RETURN $x";
-            BoltConnection_cypher(connection, cypher, strlen(cypher), 1);
-            BoltValue* x = BoltConnection_cypher_parameter(connection, 0, "x", 1);
+            BoltConnection_set_run_cypher(connection, cypher, strlen(cypher), 1);
+            BoltValue* x = BoltConnection_set_run_cypher_parameter(connection, 0, "x", 1);
             BoltValue_format_as_Integer(x, 42);
             BoltConnection_load_run_request(connection);
-            bolt_request_t run = BoltConnection_last_request(connection);
+            bolt_request run = BoltConnection_last_request(connection);
             BoltConnection_load_pull_request(connection, -1);
-            bolt_request_t pull = BoltConnection_last_request(connection);
+            bolt_request pull = BoltConnection_last_request(connection);
             BoltConnection_send(connection);
             int records = BoltConnection_fetch_summary(connection, run);
             REQUIRE(records==0);
             REQUIRE(BoltConnection_summary_success(connection)==1);
             while (BoltConnection_fetch(connection, pull)) {
-                const struct BoltValue* field_values = BoltConnection_record_fields(connection);
+                const struct BoltValue* field_values = BoltConnection_field_values(connection);
                 struct BoltValue* value = BoltList_value(field_values, 0);
                 REQUIRE(BoltValue_type(value)==BOLT_INTEGER);
                 REQUIRE(BoltInteger_get(value)==42);
@@ -306,8 +306,8 @@ SCENARIO("Test execution of multiple Cypher statements transmitted together", "[
         struct BoltConnection* connection = bolt_open_init_default();
         WHEN("successfully executed Cypher") {
             const char* cypher = "RETURN $x";
-            BoltConnection_cypher(connection, cypher, strlen(cypher), 1);
-            BoltValue* x = BoltConnection_cypher_parameter(connection, 0, "x", 1);
+            BoltConnection_set_run_cypher(connection, cypher, strlen(cypher), 1);
+            BoltValue* x = BoltConnection_set_run_cypher_parameter(connection, 0, "x", 1);
             BoltValue_format_as_Integer(x, 1);
             BoltConnection_load_run_request(connection);
             BoltConnection_load_discard_request(connection, -1);
@@ -328,21 +328,21 @@ SCENARIO("Test transactions", "[integration][ipv6][secure]")
     GIVEN("an open and initialised connection") {
         struct BoltConnection* connection = bolt_open_init_default();
         WHEN("successfully executed Cypher") {
-            BoltConnection_load_begin_request(connection);
-            bolt_request_t begin = BoltConnection_last_request(connection);
+            BoltConnection_load_begin_tx_request(connection);
+            bolt_request begin = BoltConnection_last_request(connection);
 
             const char* cypher = "RETURN 1";
-            BoltConnection_cypher(connection, cypher, strlen(cypher), 0);
+            BoltConnection_set_run_cypher(connection, cypher, strlen(cypher), 0);
             BoltConnection_load_run_request(connection);
-            bolt_request_t run = BoltConnection_last_request(connection);
+            bolt_request run = BoltConnection_last_request(connection);
             BoltConnection_load_pull_request(connection, -1);
-            bolt_request_t pull = BoltConnection_last_request(connection);
+            bolt_request pull = BoltConnection_last_request(connection);
 
             BoltConnection_load_commit_request(connection);
-            bolt_request_t commit = BoltConnection_last_request(connection);
+            bolt_request commit = BoltConnection_last_request(connection);
 
             BoltConnection_send(connection);
-            bolt_request_t last = BoltConnection_last_request(connection);
+            bolt_request last = BoltConnection_last_request(connection);
             REQUIRE(last==commit);
 
             int records = BoltConnection_fetch_summary(connection, begin);
@@ -354,7 +354,7 @@ SCENARIO("Test transactions", "[integration][ipv6][secure]")
             REQUIRE(BoltConnection_summary_success(connection)==1);
 
             while (BoltConnection_fetch(connection, pull)) {
-                const struct BoltValue* field_values = BoltConnection_record_fields(connection);
+                const struct BoltValue* field_values = BoltConnection_field_values(connection);
                 struct BoltValue* value = BoltList_value(field_values, 0);
                 REQUIRE(BoltValue_type(value)==BOLT_INTEGER);
                 REQUIRE(BoltInteger_get(value)==1);
@@ -378,7 +378,7 @@ SCENARIO("Test FAILURE", "[integration][ipv6][secure]")
         auto connection = bolt_open_init_default();
         WHEN("an invalid cypher statement is sent") {
             const auto cypher = "some invalid statement";
-            BoltConnection_cypher(connection, cypher, strlen(cypher), 0);
+            BoltConnection_set_run_cypher(connection, cypher, strlen(cypher), 0);
             BoltConnection_load_run_request(connection);
             const auto run = BoltConnection_last_request(connection);
             BoltConnection_load_pull_request(connection, -1);
@@ -426,7 +426,7 @@ SCENARIO("Test FAILURE", "[integration][ipv6][secure]")
 
             THEN("upcoming requests should be IGNORED after FAILURE") {
                 const auto cypher1 = "RETURN 1";
-                BoltConnection_cypher(connection, cypher1, strlen(cypher1), 0);
+                BoltConnection_set_run_cypher(connection, cypher1, strlen(cypher1), 0);
                 BoltConnection_load_run_request(connection);
                 const auto run1 = BoltConnection_last_request(connection);
 

--- a/seabolt-integration-test/src/test_direct.cpp
+++ b/seabolt-integration-test/src/test_direct.cpp
@@ -328,7 +328,7 @@ SCENARIO("Test transactions", "[integration][ipv6][secure]")
     GIVEN("an open and initialised connection") {
         struct BoltConnection* connection = bolt_open_init_default();
         WHEN("successfully executed Cypher") {
-            BoltConnection_load_begin_tx_request(connection);
+            BoltConnection_load_begin_request(connection);
             bolt_request begin = BoltConnection_last_request(connection);
 
             const char* cypher = "RETURN 1";
@@ -399,7 +399,8 @@ SCENARIO("Test FAILURE", "[integration][ipv6][secure]")
                 struct BoltValue* message = BoltDictionary_value_by_key(failure_data, "message", strlen("message"));
                 REQUIRE(code!=nullptr);
                 REQUIRE(BoltValue_type(code)==BOLT_STRING);
-                REQUIRE(BoltString_equals(code, "Neo.ClientError.Statement.SyntaxError"));
+                REQUIRE(BoltString_equals(code, "Neo.ClientError.Statement.SyntaxError",
+                        strlen("Neo.ClientError.Statement.SyntaxError")));
                 REQUIRE(message!=nullptr);
                 REQUIRE(BoltValue_type(message)==BOLT_STRING);
             }
@@ -419,7 +420,8 @@ SCENARIO("Test FAILURE", "[integration][ipv6][secure]")
                 struct BoltValue* message = BoltDictionary_value_by_key(failure_data, "message", strlen("message"));
                 REQUIRE(code!=nullptr);
                 REQUIRE(BoltValue_type(code)==BOLT_STRING);
-                REQUIRE(BoltString_equals(code, "Neo.ClientError.Statement.SyntaxError"));
+                REQUIRE(BoltString_equals(code, "Neo.ClientError.Statement.SyntaxError",
+                        strlen("Neo.ClientError.Statement.SyntaxError")));
                 REQUIRE(message!=nullptr);
                 REQUIRE(BoltValue_type(message)==BOLT_STRING);
             }
@@ -445,7 +447,8 @@ SCENARIO("Test FAILURE", "[integration][ipv6][secure]")
                 struct BoltValue* message = BoltDictionary_value_by_key(failure_data, "message", strlen("message"));
                 REQUIRE(code!=nullptr);
                 REQUIRE(BoltValue_type(code)==BOLT_STRING);
-                REQUIRE(BoltString_equals(code, "Neo.ClientError.Statement.SyntaxError"));
+                REQUIRE(BoltString_equals(code, "Neo.ClientError.Statement.SyntaxError",
+                        strlen("Neo.ClientError.Statement.SyntaxError")));
                 REQUIRE(message!=nullptr);
                 REQUIRE(BoltValue_type(message)==BOLT_STRING);
             }

--- a/seabolt-integration-test/src/test_pooling.cpp
+++ b/seabolt-integration-test/src/test_pooling.cpp
@@ -85,7 +85,7 @@ SCENARIO("Test reusing a pooled connection that was abandoned", "[integration][i
                 REQUIRE(result1.connection!=nullptr);
             }
             const char* cypher = "RETURN 1";
-            BoltConnection_cypher(result1.connection, cypher, strlen(cypher), 0);
+            BoltConnection_set_run_cypher(result1.connection, cypher, strlen(cypher), 0);
             BoltConnection_load_run_request(result1.connection);
             BoltConnection_send(result1.connection);
             BoltConnector_release(connector, result1.connection);

--- a/seabolt-integration-test/src/test_values.cpp
+++ b/seabolt-integration-test/src/test_values.cpp
@@ -430,7 +430,7 @@ SCENARIO("Test structure in result", "[integration][ipv6][secure]")
     GIVEN("an open and initialised connection") {
         struct BoltConnection* connection = bolt_open_init_default();
         WHEN("successfully executed Cypher") {
-            BoltConnection_load_begin_tx_request(connection);
+            BoltConnection_load_begin_request(connection);
             const char* cypher = "CREATE (a:Person {name:'Alice'}) RETURN a";
             BoltConnection_set_run_cypher(connection, cypher, strlen(cypher), 0);
             BoltConnection_load_run_request(connection);

--- a/seabolt-integration-test/src/test_values.cpp
+++ b/seabolt-integration-test/src/test_values.cpp
@@ -38,7 +38,7 @@ using Catch::Matchers::Equals;
     BoltConnection_load_run_request(connection);\
     BoltConnection_load_pull_request(connection, -1);\
     BoltConnection_send(connection);\
-    bolt_request_t (result) = BoltConnection_last_request(connection);
+    bolt_request (result) = BoltConnection_last_request(connection);
 
 SCENARIO("Test null parameter", "[integration][ipv6][secure]")
 {
@@ -46,12 +46,12 @@ SCENARIO("Test null parameter", "[integration][ipv6][secure]")
         struct BoltConnection* connection = bolt_open_init_default();
         WHEN("successfully executed Cypher") {
             const char* cypher = "RETURN $x";
-            BoltConnection_cypher(connection, cypher, strlen(cypher), 1);
-            BoltValue* x = BoltConnection_cypher_parameter(connection, 0, "x", 1);
+            BoltConnection_set_run_cypher(connection, cypher, strlen(cypher), 1);
+            BoltValue* x = BoltConnection_set_run_cypher_parameter(connection, 0, "x", 1);
             BoltValue_format_as_Null(x);
             RUN_PULL_SEND(connection, result);
             while (BoltConnection_fetch(connection, result)) {
-                const struct BoltValue* field_values = BoltConnection_record_fields(connection);
+                const struct BoltValue* field_values = BoltConnection_field_values(connection);
                 struct BoltValue* value = BoltList_value(field_values, 0);
                 REQUIRE_BOLT_NULL(value);
             }
@@ -67,12 +67,12 @@ SCENARIO("Test boolean in, boolean out", "[integration][ipv6][secure]")
         struct BoltConnection* connection = bolt_open_init_default();
         WHEN("successfully executed Cypher") {
             const char* cypher = "RETURN $x";
-            BoltConnection_cypher(connection, cypher, strlen(cypher), 1);
-            BoltValue* x = BoltConnection_cypher_parameter(connection, 0, "x", 1);
+            BoltConnection_set_run_cypher(connection, cypher, strlen(cypher), 1);
+            BoltValue* x = BoltConnection_set_run_cypher_parameter(connection, 0, "x", 1);
             BoltValue_format_as_Boolean(x, 1);
             RUN_PULL_SEND(connection, result);
             while (BoltConnection_fetch(connection, result)) {
-                const struct BoltValue* field_values = BoltConnection_record_fields(connection);
+                const struct BoltValue* field_values = BoltConnection_field_values(connection);
                 struct BoltValue* value = BoltList_value(field_values, 0);
                 REQUIRE_BOLT_BOOLEAN(value, 1);
             }
@@ -88,13 +88,13 @@ SCENARIO("Test bytes in, bytes out", "[integration][ipv6][secure]")
         struct BoltConnection* connection = bolt_open_init_default();
         WHEN("successfully executed Cypher") {
             const char* cypher = "RETURN $x";
-            BoltConnection_cypher(connection, cypher, strlen(cypher), 1);
-            BoltValue* x = BoltConnection_cypher_parameter(connection, 0, "x", 1);
+            BoltConnection_set_run_cypher(connection, cypher, strlen(cypher), 1);
+            BoltValue* x = BoltConnection_set_run_cypher_parameter(connection, 0, "x", 1);
             char array[5] = {33, 44, 55, 66, 77};
             BoltValue_format_as_Bytes(x, &array[0], sizeof(array));
             RUN_PULL_SEND(connection, result);
             while (BoltConnection_fetch(connection, result)) {
-                const struct BoltValue* field_values = BoltConnection_record_fields(connection);
+                const struct BoltValue* field_values = BoltConnection_field_values(connection);
                 struct BoltValue* value = BoltList_value(field_values, 0);
                 REQUIRE_BOLT_BYTES(value, 5);
             }
@@ -110,12 +110,12 @@ SCENARIO("Test string in, string out", "[integration][ipv6][secure]")
         struct BoltConnection* connection = bolt_open_init_default();
         WHEN("successfully executed Cypher") {
             const char* cypher = "RETURN $x";
-            BoltConnection_cypher(connection, cypher, strlen(cypher), 1);
-            BoltValue* x = BoltConnection_cypher_parameter(connection, 0, "x", 1);
+            BoltConnection_set_run_cypher(connection, cypher, strlen(cypher), 1);
+            BoltValue* x = BoltConnection_set_run_cypher_parameter(connection, 0, "x", 1);
             BoltValue_format_as_String(x, "hello, world", 12);
             RUN_PULL_SEND(connection, result);
             while (BoltConnection_fetch(connection, result)) {
-                const struct BoltValue* field_values = BoltConnection_record_fields(connection);
+                const struct BoltValue* field_values = BoltConnection_field_values(connection);
                 struct BoltValue* value = BoltList_value(field_values, 0);
                 REQUIRE_BOLT_STRING(value, "hello, world", 12);
             }
@@ -131,15 +131,15 @@ SCENARIO("Test list in, list out", "[integration][ipv6][secure]")
         struct BoltConnection* connection = bolt_open_init_default();
         WHEN("successfully executed Cypher") {
             const char* cypher = "RETURN $x";
-            REQUIRE(BoltConnection_cypher(connection, cypher, strlen(cypher), 1)==0);
-            BoltValue* x = BoltConnection_cypher_parameter(connection, 0, "x", 1);
+            REQUIRE(BoltConnection_set_run_cypher(connection, cypher, strlen(cypher), 1)==0);
+            BoltValue* x = BoltConnection_set_run_cypher_parameter(connection, 0, "x", 1);
             BoltValue_format_as_List(x, 3);
             BoltValue_format_as_Integer(BoltList_value(x, 0), 0);
             BoltValue_format_as_Integer(BoltList_value(x, 1), 1);
             BoltValue_format_as_Integer(BoltList_value(x, 2), 2);
             RUN_PULL_SEND(connection, result);
             while (BoltConnection_fetch(connection, result)) {
-                BoltValue* field_values = BoltConnection_record_fields(connection);
+                BoltValue* field_values = BoltConnection_field_values(connection);
                 BoltValue* value = BoltList_value(field_values, 0);
                 REQUIRE_BOLT_LIST(value, 3);
                 REQUIRE(BoltInteger_get(BoltList_value(value, 0))==0);
@@ -158,12 +158,12 @@ SCENARIO("Test empty list in, empty list out", "[integration][ipv6][secure]")
         struct BoltConnection* connection = bolt_open_init_default();
         WHEN("successfully executed Cypher") {
             const char* cypher = "RETURN $x";
-            REQUIRE(BoltConnection_cypher(connection, cypher, strlen(cypher), 1)==0);
-            BoltValue* x = BoltConnection_cypher_parameter(connection, 0, "x", 1);
+            REQUIRE(BoltConnection_set_run_cypher(connection, cypher, strlen(cypher), 1)==0);
+            BoltValue* x = BoltConnection_set_run_cypher_parameter(connection, 0, "x", 1);
             BoltValue_format_as_List(x, 0);
             RUN_PULL_SEND(connection, result);
             while (BoltConnection_fetch(connection, result)) {
-                BoltValue* field_values = BoltConnection_record_fields(connection);
+                BoltValue* field_values = BoltConnection_field_values(connection);
                 BoltValue* value = BoltList_value(field_values, 0);
                 REQUIRE_BOLT_LIST(value, 0);
             }
@@ -179,8 +179,8 @@ SCENARIO("Test mixed list in, mixed list out", "[integration][ipv6][secure]")
         struct BoltConnection* connection = bolt_open_init_default();
         WHEN("successfully executed Cypher") {
             const char* cypher = "RETURN $x";
-            REQUIRE(BoltConnection_cypher(connection, cypher, strlen(cypher), 1)==0);
-            BoltValue* x = BoltConnection_cypher_parameter(connection, 0, "x", 1);
+            REQUIRE(BoltConnection_set_run_cypher(connection, cypher, strlen(cypher), 1)==0);
+            BoltValue* x = BoltConnection_set_run_cypher_parameter(connection, 0, "x", 1);
 
             // list [42, "hello", false, 42.4242, {key1: "value1", key2: -424242}]
             BoltValue_format_as_List(x, 5);
@@ -197,7 +197,7 @@ SCENARIO("Test mixed list in, mixed list out", "[integration][ipv6][secure]")
 
             RUN_PULL_SEND(connection, result);
             while (BoltConnection_fetch(connection, result)) {
-                BoltValue* field_values = BoltConnection_record_fields(connection);
+                BoltValue* field_values = BoltConnection_field_values(connection);
                 BoltValue* value = BoltList_value(field_values, 0);
                 REQUIRE_BOLT_LIST(value, 5);
                 REQUIRE(BoltInteger_get(BoltList_value(value, 0))==42);
@@ -222,8 +222,8 @@ SCENARIO("Test dictionary in, dictionary out", "[integration][ipv6][secure]")
         struct BoltConnection* connection = bolt_open_init_default();
         WHEN("successfully executed Cypher") {
             const char* cypher = "RETURN $x";
-            BoltConnection_cypher(connection, cypher, strlen(cypher), 1);
-            BoltValue* x = BoltConnection_cypher_parameter(connection, 0, "x", 1);
+            BoltConnection_set_run_cypher(connection, cypher, strlen(cypher), 1);
+            BoltValue* x = BoltConnection_set_run_cypher_parameter(connection, 0, "x", 1);
             BoltValue_format_as_Dictionary(x, 2);
             BoltDictionary_set_key(x, 0, "name", 4);
             BoltValue_format_as_String(BoltDictionary_value(x, 0), "Alice", 5);
@@ -231,7 +231,7 @@ SCENARIO("Test dictionary in, dictionary out", "[integration][ipv6][secure]")
             BoltValue_format_as_Integer(BoltDictionary_value(x, 1), 33);
             RUN_PULL_SEND(connection, result);
             while (BoltConnection_fetch(connection, result)) {
-                const struct BoltValue* field_values = BoltConnection_record_fields(connection);
+                const struct BoltValue* field_values = BoltConnection_field_values(connection);
                 struct BoltValue* dict = BoltList_value(field_values, 0);
                 REQUIRE_BOLT_DICTIONARY(dict, 2);
                 int found = 0;
@@ -263,12 +263,12 @@ SCENARIO("Test empty dictionary in, empty dictionary out", "[integration][ipv6][
         struct BoltConnection* connection = bolt_open_init_default();
         WHEN("successfully executed Cypher") {
             const char* cypher = "RETURN $x";
-            BoltConnection_cypher(connection, cypher, strlen(cypher), 1);
-            BoltValue* x = BoltConnection_cypher_parameter(connection, 0, "x", 1);
+            BoltConnection_set_run_cypher(connection, cypher, strlen(cypher), 1);
+            BoltValue* x = BoltConnection_set_run_cypher_parameter(connection, 0, "x", 1);
             BoltValue_format_as_Dictionary(x, 0);
             RUN_PULL_SEND(connection, result);
             while (BoltConnection_fetch(connection, result)) {
-                const struct BoltValue* field_values = BoltConnection_record_fields(connection);
+                const struct BoltValue* field_values = BoltConnection_field_values(connection);
                 struct BoltValue* value = BoltList_value(field_values, 0);
                 REQUIRE_BOLT_DICTIONARY(value, 0);
             }
@@ -284,8 +284,8 @@ SCENARIO("Test mixed dictionary in, mixed dictionary out", "[integration][ipv6][
         struct BoltConnection* connection = bolt_open_init_default();
         WHEN("successfully executed Cypher") {
             const char* cypher = "RETURN $x";
-            BoltConnection_cypher(connection, cypher, strlen(cypher), 1);
-            BoltValue* x = BoltConnection_cypher_parameter(connection, 0, "x", 1);
+            BoltConnection_set_run_cypher(connection, cypher, strlen(cypher), 1);
+            BoltValue* x = BoltConnection_set_run_cypher_parameter(connection, 0, "x", 1);
 
             // dictionary {k1: "apa", key2: [1.9283, "hello world!"], TheKey3: true}
             BoltValue_format_as_Dictionary(x, 3);
@@ -303,7 +303,7 @@ SCENARIO("Test mixed dictionary in, mixed dictionary out", "[integration][ipv6][
 
             RUN_PULL_SEND(connection, result);
             while (BoltConnection_fetch(connection, result)) {
-                const struct BoltValue* field_values = BoltConnection_record_fields(connection);
+                const struct BoltValue* field_values = BoltConnection_field_values(connection);
                 struct BoltValue* value = BoltList_value(field_values, 0);
                 REQUIRE_BOLT_DICTIONARY(value, 3);
                 CHECK_THAT(BoltString_get(BoltDictionary_value_by_key(value, "k1", 2)), Equals("apa"));
@@ -327,12 +327,12 @@ SCENARIO("Test integer in, integer out", "[integration][ipv6][secure]")
         struct BoltConnection* connection = bolt_open_init_default();
         WHEN("successfully executed Cypher") {
             const char* cypher = "RETURN $x";
-            BoltConnection_cypher(connection, cypher, strlen(cypher), 1);
-            BoltValue* x = BoltConnection_cypher_parameter(connection, 0, "x", 1);
+            BoltConnection_set_run_cypher(connection, cypher, strlen(cypher), 1);
+            BoltValue* x = BoltConnection_set_run_cypher_parameter(connection, 0, "x", 1);
             BoltValue_format_as_Integer(x, 123456789);
             RUN_PULL_SEND(connection, result);
             while (BoltConnection_fetch(connection, result)) {
-                const struct BoltValue* field_values = BoltConnection_record_fields(connection);
+                const struct BoltValue* field_values = BoltConnection_field_values(connection);
                 struct BoltValue* value = BoltList_value(field_values, 0);
                 REQUIRE_BOLT_INTEGER(value, 123456789);
             }
@@ -348,13 +348,13 @@ SCENARIO("Test max & min integer in, max & min integer out", "[integration][ipv6
         struct BoltConnection* connection = bolt_open_init_default();
         WHEN("successfully executed Cypher") {
             const char* cypher = "RETURN $x";
-            BoltConnection_cypher(connection, cypher, strlen(cypher), 1);
-            BoltValue* x = BoltConnection_cypher_parameter(connection, 0, "x", 1);
+            BoltConnection_set_run_cypher(connection, cypher, strlen(cypher), 1);
+            BoltValue* x = BoltConnection_set_run_cypher_parameter(connection, 0, "x", 1);
 
             BoltValue_format_as_Integer(x, INT64_MAX);
             RUN_PULL_SEND(connection, result1);
             while (BoltConnection_fetch(connection, result1)) {
-                const struct BoltValue* field_values = BoltConnection_record_fields(connection);
+                const struct BoltValue* field_values = BoltConnection_field_values(connection);
                 struct BoltValue* value = BoltList_value(field_values, 0);
                 REQUIRE_BOLT_INTEGER(value, INT64_MAX);
             }
@@ -362,7 +362,7 @@ SCENARIO("Test max & min integer in, max & min integer out", "[integration][ipv6
             BoltValue_format_as_Integer(x, INT64_MIN);
             RUN_PULL_SEND(connection, result2);
             while (BoltConnection_fetch(connection, result2)) {
-                const struct BoltValue* field_values = BoltConnection_record_fields(connection);
+                const struct BoltValue* field_values = BoltConnection_field_values(connection);
                 struct BoltValue* value = BoltList_value(field_values, 0);
                 REQUIRE_BOLT_INTEGER(value, INT64_MIN);
             }
@@ -379,12 +379,12 @@ SCENARIO("Test float in, float out", "[integration][ipv6][secure]")
         struct BoltConnection* connection = bolt_open_init_default();
         WHEN("successfully executed Cypher") {
             const char* cypher = "RETURN $x";
-            BoltConnection_cypher(connection, cypher, strlen(cypher), 1);
-            BoltValue* x = BoltConnection_cypher_parameter(connection, 0, "x", 1);
+            BoltConnection_set_run_cypher(connection, cypher, strlen(cypher), 1);
+            BoltValue* x = BoltConnection_set_run_cypher_parameter(connection, 0, "x", 1);
             BoltValue_format_as_Float(x, 6.283185307179);
             RUN_PULL_SEND(connection, result);
             while (BoltConnection_fetch(connection, result)) {
-                const struct BoltValue* field_values = BoltConnection_record_fields(connection);
+                const struct BoltValue* field_values = BoltConnection_field_values(connection);
                 struct BoltValue* value = BoltList_value(field_values, 0);
                 REQUIRE_BOLT_FLOAT(value, 6.283185307179);
             }
@@ -400,13 +400,13 @@ SCENARIO("Test max & min float in, max & min float out", "[integration][ipv6][se
         struct BoltConnection* connection = bolt_open_init_default();
         WHEN("successfully executed Cypher") {
             const char* cypher = "RETURN $x";
-            BoltConnection_cypher(connection, cypher, strlen(cypher), 1);
-            BoltValue* x = BoltConnection_cypher_parameter(connection, 0, "x", 1);
+            BoltConnection_set_run_cypher(connection, cypher, strlen(cypher), 1);
+            BoltValue* x = BoltConnection_set_run_cypher_parameter(connection, 0, "x", 1);
 
             BoltValue_format_as_Float(x, 1.7976931348623157E308);
             RUN_PULL_SEND(connection, result1);
             while (BoltConnection_fetch(connection, result1)) {
-                const struct BoltValue* field_values = BoltConnection_record_fields(connection);
+                const struct BoltValue* field_values = BoltConnection_field_values(connection);
                 struct BoltValue* value = BoltList_value(field_values, 0);
                 REQUIRE_BOLT_FLOAT(value, 1.7976931348623157E308);
             }
@@ -414,7 +414,7 @@ SCENARIO("Test max & min float in, max & min float out", "[integration][ipv6][se
             BoltValue_format_as_Float(x, 4.9E-324);
             RUN_PULL_SEND(connection, result2);
             while (BoltConnection_fetch(connection, result2)) {
-                const struct BoltValue* field_values = BoltConnection_record_fields(connection);
+                const struct BoltValue* field_values = BoltConnection_field_values(connection);
                 struct BoltValue* value = BoltList_value(field_values, 0);
                 REQUIRE_BOLT_FLOAT(value, 4.9E-324);
             }
@@ -430,17 +430,17 @@ SCENARIO("Test structure in result", "[integration][ipv6][secure]")
     GIVEN("an open and initialised connection") {
         struct BoltConnection* connection = bolt_open_init_default();
         WHEN("successfully executed Cypher") {
-            BoltConnection_load_begin_request(connection);
+            BoltConnection_load_begin_tx_request(connection);
             const char* cypher = "CREATE (a:Person {name:'Alice'}) RETURN a";
-            BoltConnection_cypher(connection, cypher, strlen(cypher), 0);
+            BoltConnection_set_run_cypher(connection, cypher, strlen(cypher), 0);
             BoltConnection_load_run_request(connection);
             BoltConnection_load_pull_request(connection, -1);
-            bolt_request_t result = BoltConnection_last_request(connection);
+            bolt_request result = BoltConnection_last_request(connection);
             BoltConnection_load_rollback_request(connection);
             BoltConnection_send(connection);
-            bolt_request_t last = BoltConnection_last_request(connection);
+            bolt_request last = BoltConnection_last_request(connection);
             while (BoltConnection_fetch(connection, result)) {
-                const struct BoltValue* field_values = BoltConnection_record_fields(connection);
+                const struct BoltValue* field_values = BoltConnection_field_values(connection);
                 struct BoltValue* node = BoltList_value(field_values, 0);
                 REQUIRE_BOLT_STRUCTURE(node, 'N', 3);
                 BoltValue* id = BoltStructure_value(node, 0);

--- a/seabolt-test/src/mocks.cpp
+++ b/seabolt-test/src/mocks.cpp
@@ -87,7 +87,7 @@ int BoltConnection_load_reset_request(struct BoltConnection* connection)
     return 0;
 }
 
-bolt_request_t BoltConnection_last_request(struct BoltConnection* connection)
+bolt_request BoltConnection_last_request(struct BoltConnection* connection)
 {
     return 0;
 }
@@ -97,7 +97,7 @@ int BoltConnection_send(struct BoltConnection* connection)
     return 0;
 }
 
-int BoltConnection_fetch_summary(struct BoltConnection* connection, bolt_request_t request)
+int BoltConnection_fetch_summary(struct BoltConnection* connection, bolt_request request)
 {
     return 0;
 }
@@ -129,17 +129,17 @@ int BoltConnection_load_pull_request(struct BoltConnection* connection, int32_t 
     return 0;
 }
 
-struct BoltValue* BoltConnection_record_fields(struct BoltConnection* connection)
+struct BoltValue* BoltConnection_field_values(struct BoltConnection* connection)
 {
     return BoltValue_create();
 }
 
-struct BoltValue* BoltConnection_fields(struct BoltConnection* connection)
+struct BoltValue* BoltConnection_field_names(struct BoltConnection* connection)
 {
     return BoltValue_create();
 }
 
-int BoltConnection_fetch(struct BoltConnection* connection, bolt_request_t request)
+int BoltConnection_fetch(struct BoltConnection* connection, bolt_request request)
 {
     return 0;
 }

--- a/seabolt/include/bolt/connections.h
+++ b/seabolt/include/bolt/connections.h
@@ -294,9 +294,9 @@ PUBLIC int BoltConnection_fetch_summary(struct BoltConnection* connection, bolt_
  * @param connection
  * @return
  */
-PUBLIC int BoltConnection_clear_begin_tx(struct BoltConnection* connection);
+PUBLIC int BoltConnection_clear_begin(struct BoltConnection* connection);
 
-PUBLIC int BoltConnection_set_begin_tx_bookmark(struct BoltConnection* connection, struct BoltValue* bookmark_list);
+PUBLIC int BoltConnection_set_begin_bookmarks(struct BoltConnection* connection, struct BoltValue* bookmark_list);
 
 PUBLIC int BoltConnection_set_begin_tx_timeout(struct BoltConnection* connection, int64_t timeout);
 
@@ -308,7 +308,7 @@ PUBLIC int BoltConnection_set_begin_tx_metadata(struct BoltConnection* connectio
  * @param connection
  * @return
  */
-PUBLIC int BoltConnection_load_begin_tx_request(struct BoltConnection* connection);
+PUBLIC int BoltConnection_load_begin_request(struct BoltConnection* connection);
 
 /**
  * Load a transaction COMMIT request into the request queue.
@@ -334,7 +334,7 @@ PUBLIC int BoltConnection_load_rollback_request(struct BoltConnection* connectio
  */
 PUBLIC int BoltConnection_clear_run(struct BoltConnection* connection);
 
-PUBLIC int BoltConnection_set_run_bookmark(struct BoltConnection* connection, struct BoltValue* bookmark_list);
+PUBLIC int BoltConnection_set_run_bookmarks(struct BoltConnection* connection, struct BoltValue* bookmark_list);
 
 PUBLIC int BoltConnection_set_run_tx_timeout(struct BoltConnection* connection, int64_t timeout);
 

--- a/seabolt/include/bolt/connections.h
+++ b/seabolt/include/bolt/connections.h
@@ -298,7 +298,7 @@ PUBLIC int BoltConnection_clear_begin_tx(struct BoltConnection* connection);
 
 PUBLIC int BoltConnection_set_begin_tx_bookmark(struct BoltConnection* connection, struct BoltValue* bookmark_list);
 
-PUBLIC int BoltConnection_set_begin_tx_timeout(struct BoltConnection* connection, int32_t timeout);
+PUBLIC int BoltConnection_set_begin_tx_timeout(struct BoltConnection* connection, int64_t timeout);
 
 PUBLIC int BoltConnection_set_begin_tx_metadata(struct BoltConnection* connection, struct BoltValue* metadata);
 
@@ -336,7 +336,7 @@ PUBLIC int BoltConnection_clear_run(struct BoltConnection* connection);
 
 PUBLIC int BoltConnection_set_run_bookmark(struct BoltConnection* connection, struct BoltValue* bookmark_list);
 
-PUBLIC int BoltConnection_set_run_tx_timeout(struct BoltConnection* connection, int32_t timeout);
+PUBLIC int BoltConnection_set_run_tx_timeout(struct BoltConnection* connection, int64_t timeout);
 
 PUBLIC int BoltConnection_set_run_tx_metadata(struct BoltConnection* connection, struct BoltValue* metadata);
 

--- a/seabolt/include/bolt/connections.h
+++ b/seabolt/include/bolt/connections.h
@@ -32,7 +32,7 @@
 #include "config.h"
 #include "values.h"
 
-typedef uint64_t bolt_request_t;
+typedef uint64_t bolt_request;
 
 /**
  *
@@ -92,6 +92,8 @@ enum BoltConnectionError {
 
 struct BoltConnection;
 
+struct BoltProtocol;
+
 typedef void (* error_action_func)(struct BoltConnection*, void*);
 
 /**
@@ -130,7 +132,7 @@ struct BoltConnection {
     /// The protocol version used for this connection
     int32_t protocol_version;
     /// State required by the protocol
-    void* protocol_state;
+    struct BoltProtocol* protocol;
 
     // These buffers contain data exactly as it is transmitted or
     // received. Therefore for Bolt v1, chunk headers are included
@@ -264,7 +266,7 @@ int BoltConnection_receive(struct BoltConnection* connection, char* buffer, int 
  *         -1 if an error occurs
  *
  */
-PUBLIC int BoltConnection_fetch(struct BoltConnection* connection, bolt_request_t request);
+PUBLIC int BoltConnection_fetch(struct BoltConnection* connection, bolt_request request);
 
 /**
  * Fetch values from the result stream for a given request, up to and
@@ -284,40 +286,7 @@ PUBLIC int BoltConnection_fetch(struct BoltConnection* connection, bolt_request_
  * @return >=0 the number of records discarded from this result
  *         -1 if an error occurs
  */
-PUBLIC int BoltConnection_fetch_summary(struct BoltConnection* connection, bolt_request_t request);
-
-/**
- * Set the next Cypher statement template to be run on this connection.
- *
- * @param connection
- * @param cypher
- * @param cypher_size
- * @param n_parameters
- * @return
- */
-PUBLIC int BoltConnection_cypher(struct BoltConnection* connection, const char* cypher, size_t cypher_size,
-        int32_t n_parameters);
-
-/**
- * Return a pointer to a Cypher parameter.
- *
- * @param connection
- * @param index
- * @param key
- * @param key_size
- * @return
- */
-PUBLIC struct BoltValue* BoltConnection_cypher_parameter(struct BoltConnection* connection, int32_t index,
-        const char* key, size_t key_size);
-
-/**
- * Load a bookmark to be used when beginning the next transaction.
- *
- * @param connection
- * @param bookmark
- * @return
- */
-PUBLIC int BoltConnection_load_bookmark(struct BoltConnection* connection, const char* bookmark);
+PUBLIC int BoltConnection_fetch_summary(struct BoltConnection* connection, bolt_request request);
 
 /**
  * Load a transaction BEGIN request into the request queue.
@@ -325,7 +294,21 @@ PUBLIC int BoltConnection_load_bookmark(struct BoltConnection* connection, const
  * @param connection
  * @return
  */
-PUBLIC int BoltConnection_load_begin_request(struct BoltConnection* connection);
+PUBLIC int BoltConnection_clear_begin_tx(struct BoltConnection* connection);
+
+PUBLIC int BoltConnection_set_begin_tx_bookmark(struct BoltConnection* connection, struct BoltValue* bookmark_list);
+
+PUBLIC int BoltConnection_set_begin_tx_timeout(struct BoltConnection* connection, int32_t timeout);
+
+PUBLIC int BoltConnection_set_begin_tx_metadata(struct BoltConnection* connection, struct BoltValue* metadata);
+
+/**
+ * Load a transaction BEGIN request into the request queue.
+ *
+ * @param connection
+ * @return
+ */
+PUBLIC int BoltConnection_load_begin_tx_request(struct BoltConnection* connection);
 
 /**
  * Load a transaction COMMIT request into the request queue.
@@ -349,6 +332,22 @@ PUBLIC int BoltConnection_load_rollback_request(struct BoltConnection* connectio
  * @param connection
  * @return
  */
+PUBLIC int BoltConnection_clear_run(struct BoltConnection* connection);
+
+PUBLIC int BoltConnection_set_run_bookmark(struct BoltConnection* connection, struct BoltValue* bookmark_list);
+
+PUBLIC int BoltConnection_set_run_tx_timeout(struct BoltConnection* connection, int32_t timeout);
+
+PUBLIC int BoltConnection_set_run_tx_metadata(struct BoltConnection* connection, struct BoltValue* metadata);
+
+PUBLIC int
+BoltConnection_set_run_cypher(struct BoltConnection* connection, const char* cypher, const size_t cypher_size,
+        int32_t n_parameter);
+
+PUBLIC struct BoltValue*
+BoltConnection_set_run_cypher_parameter(struct BoltConnection* connection, int32_t index, const char* name,
+        size_t name_size);
+
 PUBLIC int BoltConnection_load_run_request(struct BoltConnection* connection);
 
 /**
@@ -388,7 +387,7 @@ PUBLIC int BoltConnection_load_reset_request(struct BoltConnection* connection);
  * @param connection
  * @return
  */
-PUBLIC bolt_request_t BoltConnection_last_request(struct BoltConnection* connection);
+PUBLIC bolt_request BoltConnection_last_request(struct BoltConnection* connection);
 
 /**
  * Obtain the latest bookmark sent by the server. This may return null if
@@ -402,15 +401,6 @@ PUBLIC bolt_request_t BoltConnection_last_request(struct BoltConnection* connect
  */
 PUBLIC char* BoltConnection_last_bookmark(struct BoltConnection* connection);
 
-
-/**
-* Obtain a value from the current record.
-*
-* @param connection
-* @param field
-* @return pointer to a `BoltValue` data structure formatted as a BOLT_LIST
-*/
-PUBLIC struct BoltValue* BoltConnection_record_fields(struct BoltConnection* connection);
 
 /**
 *
@@ -433,7 +423,16 @@ PUBLIC struct BoltValue* BoltConnection_failure(struct BoltConnection* connectio
  * @param connection
  * @return
  */
-PUBLIC struct BoltValue* BoltConnection_fields(struct BoltConnection* connection);
+PUBLIC struct BoltValue* BoltConnection_field_names(struct BoltConnection* connection);
+
+/**
+* Obtain a value from the current record.
+*
+* @param connection
+* @param field
+* @return pointer to a `BoltValue` data structure formatted as a BOLT_LIST
+*/
+PUBLIC struct BoltValue* BoltConnection_field_values(struct BoltConnection* connection);
 
 /**
  * Returns the metadata sent by the server.

--- a/seabolt/include/bolt/logging.h
+++ b/seabolt/include/bolt/logging.h
@@ -56,9 +56,10 @@ void BoltLog_info(const struct BoltLog* log, const char* format, ...);
 void BoltLog_debug(const struct BoltLog* log, const char* format, ...);
 
 void
-BoltLog_value(const struct BoltLog* log, const char* format, struct BoltValue* value, int32_t protocol_version);
+BoltLog_value(const struct BoltLog* log, const char* format, struct BoltValue* value,
+        name_resolver_func struct_name_resolver);
 
-void BoltLog_message(const struct BoltLog* log, const char* peer, bolt_request_t request_id, int16_t code,
-        struct BoltValue* fields, int32_t protocol_version);
+void BoltLog_message(const struct BoltLog* log, const char* peer, bolt_request request_id, int16_t code,
+        struct BoltValue* fields, name_resolver_func struct_name_resolver, name_resolver_func message_name_resolver);
 
 #endif // SEABOLT_LOGGING

--- a/seabolt/include/bolt/values.h
+++ b/seabolt/include/bolt/values.h
@@ -206,7 +206,7 @@ PUBLIC void BoltValue_format_as_String(struct BoltValue* value, const char* data
 
 PUBLIC char* BoltString_get(const struct BoltValue* value);
 
-PUBLIC int BoltString_equals(struct BoltValue* value, const char* data);
+PUBLIC int BoltString_equals(struct BoltValue* value, const char* data, const size_t data_size);
 
 PUBLIC void BoltValue_format_as_Dictionary(struct BoltValue* value, int32_t length);
 

--- a/seabolt/include/bolt/values.h
+++ b/seabolt/include/bolt/values.h
@@ -131,7 +131,7 @@ struct BoltValue {
 
 };
 
-
+typedef const char* (* name_resolver_func)(int16_t code);
 
 /**
  * Create a new BoltValue instance.
@@ -162,7 +162,7 @@ PUBLIC struct BoltValue* BoltValue_duplicate(const struct BoltValue* value);
  * @param dest
  * @return
  */
-PUBLIC void BoltValue_copy(struct BoltValue* dest, const struct BoltValue *src);
+PUBLIC void BoltValue_copy(struct BoltValue* dest, const struct BoltValue* src);
 
 /**
  * Return the type of a BoltValue.
@@ -180,9 +180,8 @@ PUBLIC enum BoltType BoltValue_type(const struct BoltValue* value);
  * @param protocol_version
  * @return
  */
-PUBLIC int BoltValue_write(struct StringBuilder *builder, struct BoltValue* value, int32_t protocol_version);
-
-
+PUBLIC int
+BoltValue_write(struct StringBuilder* builder, struct BoltValue* value, name_resolver_func struct_name_resolver);
 
 /**
  * Set a BoltValue instance to null.

--- a/seabolt/src/bolt/connections.c
+++ b/seabolt/src/bolt/connections.c
@@ -631,7 +631,7 @@ int BoltConnection_set_begin_tx_bookmark(struct BoltConnection* connection, stru
     return BOLT_SUCCESS;
 }
 
-int BoltConnection_set_begin_tx_timeout(struct BoltConnection* connection, int32_t timeout)
+int BoltConnection_set_begin_tx_timeout(struct BoltConnection* connection, int64_t timeout)
 {
     TRY(connection->protocol->set_begin_tx_timeout(connection, timeout));
     return BOLT_SUCCESS;
@@ -688,7 +688,7 @@ int BoltConnection_set_run_bookmark(struct BoltConnection* connection, struct Bo
     return BOLT_SUCCESS;
 }
 
-int BoltConnection_set_run_tx_timeout(struct BoltConnection* connection, int32_t timeout)
+int BoltConnection_set_run_tx_timeout(struct BoltConnection* connection, int64_t timeout)
 {
     TRY(connection->protocol->set_run_tx_timeout(connection, timeout));
     return BOLT_SUCCESS;

--- a/seabolt/src/bolt/connections.c
+++ b/seabolt/src/bolt/connections.c
@@ -483,6 +483,9 @@ int BoltConnection_open(struct BoltConnection* connection, enum BoltTransport tr
 
 void BoltConnection_close(struct BoltConnection* connection)
 {
+    if (connection->status!=BOLT_DISCONNECTED) {
+        _close(connection);
+    }
     if (connection->rx_buffer!=NULL) {
         BoltBuffer_destroy(connection->rx_buffer);
         connection->rx_buffer = NULL;
@@ -490,9 +493,6 @@ void BoltConnection_close(struct BoltConnection* connection)
     if (connection->tx_buffer!=NULL) {
         BoltBuffer_destroy(connection->tx_buffer);
         connection->tx_buffer = NULL;
-    }
-    if (connection->status!=BOLT_DISCONNECTED) {
-        _close(connection);
     }
     if (connection->address!=NULL) {
         BoltAddress_destroy((struct BoltAddress*) connection->address);

--- a/seabolt/src/bolt/connections.c
+++ b/seabolt/src/bolt/connections.c
@@ -621,13 +621,13 @@ int BoltConnection_init(struct BoltConnection* connection, const char* user_agen
     }
 }
 
-int BoltConnection_clear_begin_tx(struct BoltConnection* connection)
+int BoltConnection_clear_begin(struct BoltConnection* connection)
 {
     TRY(connection->protocol->clear_begin_tx(connection));
     return BOLT_SUCCESS;
 }
 
-int BoltConnection_set_begin_tx_bookmark(struct BoltConnection* connection, struct BoltValue* bookmark_list)
+int BoltConnection_set_begin_bookmarks(struct BoltConnection* connection, struct BoltValue* bookmark_list)
 {
     TRY(connection->protocol->set_begin_tx_bookmark(connection, bookmark_list));
     return BOLT_SUCCESS;
@@ -645,7 +645,7 @@ int BoltConnection_set_begin_tx_metadata(struct BoltConnection* connection, stru
     return BOLT_SUCCESS;
 }
 
-int BoltConnection_load_begin_tx_request(struct BoltConnection* connection)
+int BoltConnection_load_begin_request(struct BoltConnection* connection)
 {
     TRY(connection->protocol->load_begin_tx(connection));
     return BOLT_SUCCESS;
@@ -684,7 +684,7 @@ BoltConnection_set_run_cypher_parameter(struct BoltConnection* connection, int32
     return connection->protocol->set_run_cypher_parameter(connection, index, name, name_size);
 }
 
-int BoltConnection_set_run_bookmark(struct BoltConnection* connection, struct BoltValue* bookmark_list)
+int BoltConnection_set_run_bookmarks(struct BoltConnection* connection, struct BoltValue* bookmark_list)
 {
     TRY(connection->protocol->set_run_bookmark(connection, bookmark_list));
     return BOLT_SUCCESS;

--- a/seabolt/src/bolt/pool/direct-pool.c
+++ b/seabolt/src/bolt/pool/direct-pool.c
@@ -109,12 +109,15 @@ void close_pool_entry(struct BoltDirectPool* pool, int index)
 {
     struct BoltConnection* connection = &pool->connections[index];
     if (connection->status!=BOLT_DISCONNECTED) {
-        struct timespec now;
-        struct timespec diff;
-        BoltUtil_get_time(&now);
-        BoltUtil_diff_time(&diff, &now, &connection->metrics.time_opened);
-        BoltLog_info(pool->config->log, "Connection alive for %lds %09ldns", (long) (diff.tv_sec),
-                diff.tv_nsec);
+        if (connection->metrics.time_opened.tv_sec!=0 || connection->metrics.time_opened.tv_nsec!=0) {
+            struct timespec now;
+            struct timespec diff;
+            BoltUtil_get_time(&now);
+            BoltUtil_diff_time(&diff, &now, &connection->metrics.time_opened);
+            BoltLog_info(pool->config->log, "Connection alive for %lds %09ldns", (long) (diff.tv_sec),
+                    diff.tv_nsec);
+        }
+
         BoltConnection_close(connection);
     }
 }

--- a/seabolt/src/bolt/pool/routing-pool.c
+++ b/seabolt/src/bolt/pool/routing-pool.c
@@ -67,11 +67,11 @@ int BoltRoutingPool_update_routing_table_from(struct BoltRoutingPool* pool, stru
 
     // Load Run message filled with discovery procedure along with routing context
     if (status==BOLT_SUCCESS) {
-        status = BoltConnection_cypher(result.connection, routing_table_call, strlen(routing_table_call), 1);
+        status = BoltConnection_set_run_cypher(result.connection, routing_table_call, strlen(routing_table_call), 1);
 
         if (status==BOLT_SUCCESS) {
-            struct BoltValue* routing_table_context = BoltConnection_cypher_parameter(result.connection, 0, "context",
-                    7);
+            struct BoltValue* routing_table_context = BoltConnection_set_run_cypher_parameter(result.connection, 0,
+                    "context", 7);
             if (pool->config->routing_context!=NULL) {
                 BoltValue_copy(routing_table_context, pool->config->routing_context);
             }
@@ -86,7 +86,7 @@ int BoltRoutingPool_update_routing_table_from(struct BoltRoutingPool* pool, stru
     }
 
     // Send pending messages
-    bolt_request_t pull_all = 0;
+    bolt_request pull_all = 0;
     if (status==BOLT_SUCCESS) {
         pull_all = BoltConnection_last_request(result.connection);
 
@@ -103,8 +103,8 @@ int BoltRoutingPool_update_routing_table_from(struct BoltRoutingPool* pool, stru
                 break;
             }
 
-            struct BoltValue* field_keys = BoltConnection_fields(result.connection);
-            struct BoltValue* field_values = BoltConnection_record_fields(result.connection);
+            struct BoltValue* field_keys = BoltConnection_field_names(result.connection);
+            struct BoltValue* field_values = BoltConnection_field_values(result.connection);
 
             response = BoltValue_create();
             BoltValue_format_as_Dictionary(response, field_keys->size);

--- a/seabolt/src/bolt/protocol/packstream.c
+++ b/seabolt/src/bolt/protocol/packstream.c
@@ -1,0 +1,533 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "packstream.h"
+#include "bolt/connections.h"
+#include "bolt/buffering.h"
+#include "bolt/logging.h"
+
+#define TRY(code) { int status_try = (code); if (status_try != BOLT_SUCCESS) { return status_try; } }
+
+int load_null(struct BoltBuffer* buffer)
+{
+    BoltBuffer_load_u8(buffer, 0xC0);
+    return BOLT_SUCCESS;
+}
+
+int load_boolean(struct BoltBuffer* buffer, int value)
+{
+    BoltBuffer_load_u8(buffer, (value==0) ? (uint8_t) (0xC2) : (uint8_t) (0xC3));
+    return BOLT_SUCCESS;
+}
+
+int load_integer(struct BoltBuffer* buffer, int64_t value)
+{
+    if (value>=-0x10 && value<0x80) {
+        BoltBuffer_load_i8(buffer, (int8_t) (value));
+    }
+    else if (value>=INT8_MIN && value<=INT8_MAX) {
+        BoltBuffer_load_u8(buffer, 0xC8);
+        BoltBuffer_load_i8(buffer, (int8_t) (value));
+    }
+    else if (value>=INT16_MIN && value<=INT16_MAX) {
+        BoltBuffer_load_u8(buffer, 0xC9);
+        BoltBuffer_load_i16be(buffer, (int16_t) (value));
+    }
+    else if (value>=INT32_MIN && value<=INT32_MAX) {
+        BoltBuffer_load_u8(buffer, 0xCA);
+        BoltBuffer_load_i32be(buffer, (int32_t) (value));
+    }
+    else {
+        BoltBuffer_load_u8(buffer, 0xCB);
+        BoltBuffer_load_i64be(buffer, value);
+    }
+    return BOLT_SUCCESS;
+}
+
+int load_float(struct BoltBuffer* buffer, double value)
+{
+    BoltBuffer_load_u8(buffer, 0xC1);
+    BoltBuffer_load_f64be(buffer, value);
+    return BOLT_SUCCESS;
+}
+
+int load_bytes(struct BoltBuffer* buffer, const char* string, int32_t size)
+{
+    if (size<0) {
+        return BOLT_PROTOCOL_VIOLATION;
+    }
+    if (size<0x100) {
+        BoltBuffer_load_u8(buffer, 0xCC);
+        BoltBuffer_load_u8(buffer, (uint8_t) (size));
+        BoltBuffer_load(buffer, string, size);
+    }
+    else if (size<0x10000) {
+        BoltBuffer_load_u8(buffer, 0xCD);
+        BoltBuffer_load_u16be(buffer, (uint16_t) (size));
+        BoltBuffer_load(buffer, string, size);
+    }
+    else {
+        BoltBuffer_load_u8(buffer, 0xCE);
+        BoltBuffer_load_i32be(buffer, size);
+        BoltBuffer_load(buffer, string, size);
+    }
+    return BOLT_SUCCESS;
+}
+
+int load_string_header(struct BoltBuffer* buffer, int32_t size)
+{
+    if (size<0) {
+        return BOLT_PROTOCOL_VIOLATION;
+    }
+    if (size<0x10) {
+        BoltBuffer_load_u8(buffer, (uint8_t) (0x80+size));
+    }
+    else if (size<0x100) {
+        BoltBuffer_load_u8(buffer, 0xD0);
+        BoltBuffer_load_u8(buffer, (uint8_t) (size));
+    }
+    else if (size<0x10000) {
+        BoltBuffer_load_u8(buffer, 0xD1);
+        BoltBuffer_load_u16be(buffer, (uint16_t) (size));
+    }
+    else {
+        BoltBuffer_load_u8(buffer, 0xD2);
+        BoltBuffer_load_i32be(buffer, size);
+    }
+    return BOLT_SUCCESS;
+}
+
+int load_string(struct BoltBuffer* buffer, const char* string, int32_t size)
+{
+    int status = load_string_header(buffer, size);
+    if (status!=BOLT_SUCCESS) return status;
+    BoltBuffer_load(buffer, string, size);
+    return BOLT_SUCCESS;
+}
+
+int load_list_header(struct BoltBuffer* buffer, int32_t size)
+{
+    if (size<0) {
+        return BOLT_PROTOCOL_VIOLATION;
+    }
+    if (size<0x10) {
+        BoltBuffer_load_u8(buffer, (uint8_t) (0x90+size));
+    }
+    else if (size<0x100) {
+        BoltBuffer_load_u8(buffer, 0xD4);
+        BoltBuffer_load_u8(buffer, (uint8_t) (size));
+    }
+    else if (size<0x10000) {
+        BoltBuffer_load_u8(buffer, 0xD5);
+        BoltBuffer_load_u16be(buffer, (uint16_t) (size));
+    }
+    else {
+        BoltBuffer_load_u8(buffer, 0xD6);
+        BoltBuffer_load_i32be(buffer, size);
+    }
+    return BOLT_SUCCESS;
+}
+
+int load_map_header(struct BoltBuffer* buffer, int32_t size)
+{
+    if (size<0) {
+        return BOLT_PROTOCOL_VIOLATION;
+    }
+    if (size<0x10) {
+        BoltBuffer_load_u8(buffer, (uint8_t) (0xA0+size));
+    }
+    else if (size<0x100) {
+        BoltBuffer_load_u8(buffer, 0xD8);
+        BoltBuffer_load_u8(buffer, (uint8_t) (size));
+    }
+    else if (size<0x10000) {
+        BoltBuffer_load_u8(buffer, 0xD9);
+        BoltBuffer_load_u16be(buffer, (uint16_t) (size));
+    }
+    else {
+        BoltBuffer_load_u8(buffer, 0xDA);
+        BoltBuffer_load_i32be(buffer, size);
+    }
+    return BOLT_SUCCESS;
+}
+
+int load_structure_header(struct BoltBuffer* buffer, int16_t code, int8_t size)
+{
+    if (code<0 || size<0 || size>=0x10) {
+        return BOLT_PROTOCOL_VIOLATION;
+    }
+    BoltBuffer_load_u8(buffer, (uint8_t) (0xB0+size));
+    BoltBuffer_load_i8(buffer, (int8_t) (code));
+    return BOLT_SUCCESS;
+}
+
+int load(check_struct_signature_func check_struct_type, struct BoltBuffer* buffer, struct BoltValue* value,
+        struct BoltLog* log)
+{
+    switch (BoltValue_type(value)) {
+    case BOLT_NULL:
+        return load_null(buffer);
+    case BOLT_LIST: {
+        TRY(load_list_header(buffer, value->size));
+        for (int32_t i = 0; i<value->size; i++) {
+            TRY(load(check_struct_type, buffer, BoltList_value(value, i), log));
+        }
+        return 0;
+    }
+    case BOLT_BOOLEAN:
+        return load_boolean(buffer, BoltBoolean_get(value));
+    case BOLT_BYTES:
+        return load_bytes(buffer, BoltBytes_get_all(value), value->size);
+    case BOLT_STRING:
+        return load_string(buffer, BoltString_get(value), value->size);
+    case BOLT_DICTIONARY: {
+        TRY(load_map_header(buffer, value->size));
+        for (int32_t i = 0; i<value->size; i++) {
+            const char* key = BoltDictionary_get_key(value, i);
+            if (key!=NULL) {
+                TRY(load_string(buffer, key, BoltDictionary_get_key_size(value, i)));
+                TRY(load(check_struct_type, buffer, BoltDictionary_value(value, i), log));
+            }
+        }
+        return BOLT_SUCCESS;
+    }
+    case BOLT_INTEGER:
+        return load_integer(buffer, BoltInteger_get(value));
+    case BOLT_FLOAT:
+        return load_float(buffer, BoltFloat_get(value));
+    case BOLT_STRUCTURE: {
+        if (check_struct_type(BoltStructure_code(value))) {
+            TRY(load_structure_header(buffer, BoltStructure_code(value), (int8_t) value->size));
+            for (int32_t i = 0; i<value->size; i++) {
+                TRY(load(check_struct_type, buffer, BoltStructure_value(value, i), log));
+            }
+            return BOLT_SUCCESS;
+        }
+        return BOLT_PROTOCOL_UNSUPPORTED_TYPE;
+    }
+    default:
+        return BOLT_PROTOCOL_NOT_IMPLEMENTED_TYPE;
+    }
+}
+
+enum PackStreamType marker_type(uint8_t marker)
+{
+    if (marker<0x80 || (marker>=0xC8 && marker<=0xCB) || marker>=0xF0) {
+        return PACKSTREAM_INTEGER;
+    }
+    if ((marker>=0x80 && marker<=0x8F) || (marker>=0xD0 && marker<=0xD2)) {
+        return PACKSTREAM_STRING;
+    }
+    if ((marker>=0x90 && marker<=0x9F) || (marker>=0xD4 && marker<=0xD6)) {
+        return PACKSTREAM_LIST;
+    }
+    if ((marker>=0xA0 && marker<=0xAF) || (marker>=0xD8 && marker<=0xDA)) {
+        return PACKSTREAM_MAP;
+    }
+    if ((marker>=0xB0 && marker<=0xBF) || (marker>=0xDC && marker<=0xDD)) {
+        return PACKSTREAM_STRUCTURE;
+    }
+    switch (marker) {
+    case 0xC0:
+        return PACKSTREAM_NULL;
+    case 0xC1:
+        return PACKSTREAM_FLOAT;
+    case 0xC2:
+    case 0xC3:
+        return PACKSTREAM_BOOLEAN;
+    case 0xCC:
+    case 0xCD:
+    case 0xCE:
+        return PACKSTREAM_BYTES;
+    default:
+        return PACKSTREAM_RESERVED;
+    }
+}
+
+int unload_null(struct BoltBuffer* recv_buffer, struct BoltValue* value)
+{
+    uint8_t marker;
+    BoltBuffer_unload_u8(recv_buffer, &marker);
+    if (marker==0xC0) {
+        BoltValue_format_as_Null(value);
+    }
+    else {
+        return BOLT_PROTOCOL_UNEXPECTED_MARKER;
+    }
+    return BOLT_SUCCESS;
+}
+
+int unload_boolean(struct BoltBuffer* recv_buffer, struct BoltValue* value)
+{
+    uint8_t marker;
+    BoltBuffer_unload_u8(recv_buffer, &marker);
+    if (marker==0xC3) {
+        BoltValue_format_as_Boolean(value, 1);
+    }
+    else if (marker==0xC2) {
+        BoltValue_format_as_Boolean(value, 0);
+    }
+    else {
+        return BOLT_PROTOCOL_UNEXPECTED_MARKER;
+    }
+    return BOLT_SUCCESS;
+}
+
+int unload_integer(struct BoltBuffer* recv_buffer, struct BoltValue* value)
+{
+    uint8_t marker;
+    BoltBuffer_unload_u8(recv_buffer, &marker);
+    if (marker<0x80) {
+        BoltValue_format_as_Integer(value, marker);
+    }
+    else if (marker>=0xF0) {
+        BoltValue_format_as_Integer(value, marker-0x100);
+    }
+    else if (marker==0xC8) {
+        int8_t x;
+        BoltBuffer_unload_i8(recv_buffer, &x);
+        BoltValue_format_as_Integer(value, x);
+    }
+    else if (marker==0xC9) {
+        int16_t x;
+        BoltBuffer_unload_i16be(recv_buffer, &x);
+        BoltValue_format_as_Integer(value, x);
+    }
+    else if (marker==0xCA) {
+        int32_t x;
+        BoltBuffer_unload_i32be(recv_buffer, &x);
+        BoltValue_format_as_Integer(value, x);
+    }
+    else if (marker==0xCB) {
+        int64_t x;
+        BoltBuffer_unload_i64be(recv_buffer, &x);
+        BoltValue_format_as_Integer(value, x);
+    }
+    else {
+        return BOLT_PROTOCOL_UNEXPECTED_MARKER;  // BOLT_ERROR_WRONG_TYPE
+    }
+    return BOLT_SUCCESS;
+}
+
+int unload_float(struct BoltBuffer* recv_buffer, struct BoltValue* value)
+{
+    uint8_t marker;
+    BoltBuffer_unload_u8(recv_buffer, &marker);
+    if (marker==0xC1) {
+        double x;
+        BoltBuffer_unload_f64be(recv_buffer, &x);
+        BoltValue_format_as_Float(value, x);
+    }
+    else {
+        return BOLT_PROTOCOL_UNEXPECTED_MARKER;  // BOLT_ERROR_WRONG_TYPE
+    }
+    return BOLT_SUCCESS;
+}
+
+int unload_string(struct BoltBuffer* recv_buffer, struct BoltValue* value, struct BoltLog* log)
+{
+    uint8_t marker;
+    BoltBuffer_unload_u8(recv_buffer, &marker);
+    if (marker>=0x80 && marker<=0x8F) {
+        int32_t size;
+        size = marker & 0x0F;
+        BoltValue_format_as_String(value, NULL, size);
+        BoltBuffer_unload(recv_buffer, BoltString_get(value), size);
+        return BOLT_SUCCESS;
+    }
+    if (marker==0xD0) {
+        uint8_t size;
+        BoltBuffer_unload_u8(recv_buffer, &size);
+        BoltValue_format_as_String(value, NULL, size);
+        BoltBuffer_unload(recv_buffer, BoltString_get(value), size);
+        return BOLT_SUCCESS;
+    }
+    if (marker==0xD1) {
+        uint16_t size;
+        BoltBuffer_unload_u16be(recv_buffer, &size);
+        BoltValue_format_as_String(value, NULL, size);
+        BoltBuffer_unload(recv_buffer, BoltString_get(value), size);
+        return BOLT_SUCCESS;
+    }
+    if (marker==0xD2) {
+        int32_t size;
+        BoltBuffer_unload_i32be(recv_buffer, &size);
+        BoltValue_format_as_String(value, NULL, size);
+        BoltBuffer_unload(recv_buffer, BoltString_get(value), size);
+        return BOLT_SUCCESS;
+    }
+    BoltLog_error(log, "Unknown marker: %d", marker);
+    return BOLT_PROTOCOL_UNEXPECTED_MARKER;
+}
+
+int unload_bytes(struct BoltBuffer* recv_buffer, struct BoltValue* value, struct BoltLog* log)
+{
+    uint8_t marker;
+    BoltBuffer_unload_u8(recv_buffer, &marker);
+    if (marker==0xCC) {
+        uint8_t size;
+        BoltBuffer_unload_u8(recv_buffer, &size);
+        BoltValue_format_as_Bytes(value, NULL, size);
+        BoltBuffer_unload(recv_buffer, BoltBytes_get_all(value), size);
+        return BOLT_SUCCESS;
+    }
+    if (marker==0xCD) {
+        uint16_t size;
+        BoltBuffer_unload_u16be(recv_buffer, &size);
+        BoltValue_format_as_Bytes(value, NULL, size);
+        BoltBuffer_unload(recv_buffer, BoltBytes_get_all(value), size);
+        return BOLT_SUCCESS;
+    }
+    if (marker==0xCE) {
+        int32_t size;
+        BoltBuffer_unload_i32be(recv_buffer, &size);
+        BoltValue_format_as_Bytes(value, NULL, size);
+        BoltBuffer_unload(recv_buffer, BoltBytes_get_all(value), size);
+        return BOLT_SUCCESS;
+    }
+    BoltLog_error(log, "Unknown marker: %d", marker);
+    return BOLT_PROTOCOL_UNEXPECTED_MARKER;
+}
+
+int unload_list(check_struct_signature_func check_struct_type, struct BoltBuffer* recv_buffer, struct BoltValue* value,
+        struct BoltLog* log)
+{
+    uint8_t marker;
+    int32_t size;
+    BoltBuffer_unload_u8(recv_buffer, &marker);
+    if (marker>=0x90 && marker<=0x9F) {
+        size = marker & 0x0F;
+    }
+    else if (marker==0xD4) {
+        uint8_t size_;
+        BoltBuffer_unload_u8(recv_buffer, &size_);
+        size = size_;
+    }
+    else if (marker==0xD5) {
+        uint16_t size_;
+        BoltBuffer_unload_u16be(recv_buffer, &size_);
+        size = size_;
+    }
+    else if (marker==0xD6) {
+        int32_t size_;
+        BoltBuffer_unload_i32be(recv_buffer, &size_);
+        size = size_;
+    }
+    else {
+        return BOLT_PROTOCOL_UNEXPECTED_MARKER;
+    }
+    if (size<0) {
+        return BOLT_PROTOCOL_VIOLATION;
+    }
+    BoltValue_format_as_List(value, size);
+    for (int i = 0; i<size; i++) {
+        TRY(unload(check_struct_type, recv_buffer, BoltList_value(value, i), log));
+    }
+    return BOLT_SUCCESS;
+}
+
+int unload_map(check_struct_signature_func check_struct_type, struct BoltBuffer* recv_buffer, struct BoltValue* value,
+        struct BoltLog* log)
+{
+    uint8_t marker;
+    int32_t size;
+    BoltBuffer_unload_u8(recv_buffer, &marker);
+    if (marker>=0xA0 && marker<=0xAF) {
+        size = marker & 0x0F;
+    }
+    else if (marker==0xD8) {
+        uint8_t size_;
+        BoltBuffer_unload_u8(recv_buffer, &size_);
+        size = size_;
+    }
+    else if (marker==0xD9) {
+        uint16_t size_;
+        BoltBuffer_unload_u16be(recv_buffer, &size_);
+        size = size_;
+    }
+    else if (marker==0xDA) {
+        int32_t size_;
+        BoltBuffer_unload_i32be(recv_buffer, &size_);
+        size = size_;
+    }
+    else {
+        return BOLT_PROTOCOL_UNEXPECTED_MARKER;
+    }
+    if (size<0) {
+        return BOLT_PROTOCOL_VIOLATION;
+    }
+    BoltValue_format_as_Dictionary(value, size);
+    for (int i = 0; i<size; i++) {
+        TRY(unload(check_struct_type, recv_buffer, BoltDictionary_key(value, i), log));
+        TRY(unload(check_struct_type, recv_buffer, BoltDictionary_value(value, i), log));
+    }
+    return BOLT_SUCCESS;
+}
+
+int
+unload_structure(check_struct_signature_func check_struct_type, struct BoltBuffer* recv_buffer, struct BoltValue* value,
+        struct BoltLog* log)
+{
+    uint8_t marker;
+    int8_t code;
+    int32_t size;
+    BoltBuffer_unload_u8(recv_buffer, &marker);
+    if (marker>=0xB0 && marker<=0xBF) {
+        size = marker & 0x0F;
+        BoltBuffer_unload_i8(recv_buffer, &code);
+        if (check_struct_type(code)) {
+            BoltValue_format_as_Structure(value, code, size);
+            for (int i = 0; i<size; i++) {
+                unload(check_struct_type, recv_buffer, BoltStructure_value(value, i), log);
+            }
+            return BOLT_SUCCESS;
+        }
+    }
+    return BOLT_PROTOCOL_UNEXPECTED_MARKER;
+}
+
+int unload(check_struct_signature_func check_struct_type, struct BoltBuffer* buffer, struct BoltValue* value,
+        struct BoltLog* log)
+{
+    uint8_t marker;
+    BoltBuffer_peek_u8(buffer, &marker);
+    switch (marker_type(marker)) {
+    case PACKSTREAM_NULL:
+        return unload_null(buffer, value);
+    case PACKSTREAM_BOOLEAN:
+        return unload_boolean(buffer, value);
+    case PACKSTREAM_INTEGER:
+        return unload_integer(buffer, value);
+    case PACKSTREAM_FLOAT:
+        return unload_float(buffer, value);
+    case PACKSTREAM_STRING:
+        return unload_string(buffer, value, log);
+    case PACKSTREAM_BYTES:
+        return unload_bytes(buffer, value, log);
+    case PACKSTREAM_LIST:
+        return unload_list(check_struct_type, buffer, value, log);
+    case PACKSTREAM_MAP:
+        return unload_map(check_struct_type, buffer, value, log);
+    case PACKSTREAM_STRUCTURE:
+        return unload_structure(check_struct_type, buffer, value, log);
+    default:
+        BoltLog_error(log, "Unknown marker: %d", marker);
+        return BOLT_PROTOCOL_UNEXPECTED_MARKER;
+    }
+}

--- a/seabolt/src/bolt/protocol/packstream.c
+++ b/seabolt/src/bolt/protocol/packstream.c
@@ -178,7 +178,7 @@ int load_structure_header(struct BoltBuffer* buffer, int16_t code, int8_t size)
 }
 
 int load(check_struct_signature_func check_struct_type, struct BoltBuffer* buffer, struct BoltValue* value,
-        struct BoltLog* log)
+        const struct BoltLog* log)
 {
     switch (BoltValue_type(value)) {
     case BOLT_NULL:
@@ -340,7 +340,7 @@ int unload_float(struct BoltBuffer* recv_buffer, struct BoltValue* value)
     return BOLT_SUCCESS;
 }
 
-int unload_string(struct BoltBuffer* recv_buffer, struct BoltValue* value, struct BoltLog* log)
+int unload_string(struct BoltBuffer* recv_buffer, struct BoltValue* value, const struct BoltLog* log)
 {
     uint8_t marker;
     BoltBuffer_unload_u8(recv_buffer, &marker);
@@ -376,7 +376,7 @@ int unload_string(struct BoltBuffer* recv_buffer, struct BoltValue* value, struc
     return BOLT_PROTOCOL_UNEXPECTED_MARKER;
 }
 
-int unload_bytes(struct BoltBuffer* recv_buffer, struct BoltValue* value, struct BoltLog* log)
+int unload_bytes(struct BoltBuffer* recv_buffer, struct BoltValue* value, const struct BoltLog* log)
 {
     uint8_t marker;
     BoltBuffer_unload_u8(recv_buffer, &marker);
@@ -406,7 +406,7 @@ int unload_bytes(struct BoltBuffer* recv_buffer, struct BoltValue* value, struct
 }
 
 int unload_list(check_struct_signature_func check_struct_type, struct BoltBuffer* recv_buffer, struct BoltValue* value,
-        struct BoltLog* log)
+        const struct BoltLog* log)
 {
     uint8_t marker;
     int32_t size;
@@ -443,7 +443,7 @@ int unload_list(check_struct_signature_func check_struct_type, struct BoltBuffer
 }
 
 int unload_map(check_struct_signature_func check_struct_type, struct BoltBuffer* recv_buffer, struct BoltValue* value,
-        struct BoltLog* log)
+        const struct BoltLog* log)
 {
     uint8_t marker;
     int32_t size;
@@ -482,7 +482,7 @@ int unload_map(check_struct_signature_func check_struct_type, struct BoltBuffer*
 
 int
 unload_structure(check_struct_signature_func check_struct_type, struct BoltBuffer* recv_buffer, struct BoltValue* value,
-        struct BoltLog* log)
+        const struct BoltLog* log)
 {
     uint8_t marker;
     int8_t code;
@@ -503,7 +503,7 @@ unload_structure(check_struct_signature_func check_struct_type, struct BoltBuffe
 }
 
 int unload(check_struct_signature_func check_struct_type, struct BoltBuffer* buffer, struct BoltValue* value,
-        struct BoltLog* log)
+        const struct BoltLog* log)
 {
     uint8_t marker;
     BoltBuffer_peek_u8(buffer, &marker);

--- a/seabolt/src/bolt/protocol/packstream.h
+++ b/seabolt/src/bolt/protocol/packstream.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef SEABOLT_ALL_PACKSTREAM_H
+#define SEABOLT_ALL_PACKSTREAM_H
+
+#include <stdint.h>
+
+#include "bolt/buffering.h"
+#include "bolt/logging.h"
+#include "bolt/values.h"
+
+enum PackStreamType {
+    PACKSTREAM_NULL,
+    PACKSTREAM_BOOLEAN,
+    PACKSTREAM_INTEGER,
+    PACKSTREAM_FLOAT,
+    PACKSTREAM_STRING,
+    PACKSTREAM_BYTES,
+    PACKSTREAM_LIST,
+    PACKSTREAM_MAP,
+    PACKSTREAM_STRUCTURE,
+    PACKSTREAM_RESERVED,
+};
+
+typedef int (* check_struct_signature_func)(int16_t);
+
+enum PackStreamType marker_type(uint8_t marker);
+
+int load_structure_header(struct BoltBuffer* buffer, int16_t code, int8_t size);
+
+int load(check_struct_signature_func check_struct_type, struct BoltBuffer* buffer, struct BoltValue* value,
+        struct BoltLog* log);
+
+int unload(check_struct_signature_func check_struct_type, struct BoltBuffer* buffer, struct BoltValue* value,
+        struct BoltLog* log);
+
+#endif //SEABOLT_ALL_PACKSTREAM_H

--- a/seabolt/src/bolt/protocol/packstream.h
+++ b/seabolt/src/bolt/protocol/packstream.h
@@ -45,9 +45,9 @@ enum PackStreamType marker_type(uint8_t marker);
 int load_structure_header(struct BoltBuffer* buffer, int16_t code, int8_t size);
 
 int load(check_struct_signature_func check_struct_type, struct BoltBuffer* buffer, struct BoltValue* value,
-        struct BoltLog* log);
+        const struct BoltLog* log);
 
 int unload(check_struct_signature_func check_struct_type, struct BoltBuffer* buffer, struct BoltValue* value,
-        struct BoltLog* log);
+        const struct BoltLog* log);
 
 #endif //SEABOLT_ALL_PACKSTREAM_H

--- a/seabolt/src/bolt/protocol/protocol.c
+++ b/seabolt/src/bolt/protocol/protocol.c
@@ -43,6 +43,15 @@ void BoltMessage_destroy(struct BoltMessage* message)
     BoltMem_deallocate(message, sizeof(struct BoltMessage));
 }
 
+struct BoltValue* BoltMessage_param(struct BoltMessage* message, int32_t index)
+{
+    if (index>=message->fields->size) {
+        return NULL;
+    }
+
+    return BoltList_value(message->fields, index);
+}
+
 int write_message(struct BoltMessage* message, check_struct_signature_func check_writable_struct,
         struct BoltBuffer* buffer, const struct BoltLog* log)
 {
@@ -56,7 +65,7 @@ int write_message(struct BoltMessage* message, check_struct_signature_func check
     return BOLT_PROTOCOL_UNSUPPORTED_TYPE;
 }
 
-int push_to_transmission(struct BoltBuffer* msg_buffer, struct BoltBuffer* tx_buffer)
+void push_to_transmission(struct BoltBuffer* msg_buffer, struct BoltBuffer* tx_buffer)
 {
     // loop through data, generate several chunks if it's larger than max chunk size
     int total_size = BoltBuffer_unloadable(msg_buffer);

--- a/seabolt/src/bolt/protocol/protocol.c
+++ b/seabolt/src/bolt/protocol/protocol.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/mem.h"
+#include "bolt/buffering.h"
+
+#include "protocol.h"
+#include "packstream.h"
+
+#define BOLT_MAX_CHUNK_SIZE 65535
+
+#define TRY(code) { int status_try = (code); if (status_try != BOLT_SUCCESS) { return status_try; } }
+
+struct BoltMessage* BoltMessage_create(int8_t code, int32_t n_fields)
+{
+    const size_t size = sizeof(struct BoltMessage);
+    struct BoltMessage* message = BoltMem_allocate(size);
+    message->code = code;
+    message->fields = BoltValue_create();
+    BoltValue_format_as_List(message->fields, n_fields);
+    return message;
+}
+
+void BoltMessage_destroy(struct BoltMessage* message)
+{
+    BoltValue_destroy(message->fields);
+    BoltMem_deallocate(message, sizeof(struct BoltMessage));
+}
+
+int write_message(struct BoltMessage* message, check_struct_signature_func check_writable_struct,
+        struct BoltBuffer* buffer, const struct BoltLog* log)
+{
+    if (check_writable_struct(message->code)) {
+        TRY(load_structure_header(buffer, message->code, (int8_t) (message->fields->size)));
+        for (int32_t i = 0; i<message->fields->size; i++) {
+            TRY(load(check_writable_struct, buffer, BoltList_value(message->fields, i), log));
+        }
+        return BOLT_SUCCESS;
+    }
+    return BOLT_PROTOCOL_UNSUPPORTED_TYPE;
+}
+
+int push_to_transmission(struct BoltBuffer* msg_buffer, struct BoltBuffer* tx_buffer)
+{
+    // loop through data, generate several chunks if it's larger than max chunk size
+    int total_size = BoltBuffer_unloadable(msg_buffer);
+    int total_remaining = total_size;
+    char header[2];
+    while (total_remaining>0) {
+        int current_size = total_remaining>BOLT_MAX_CHUNK_SIZE ? BOLT_MAX_CHUNK_SIZE : total_remaining;
+        header[0] = (char) (current_size >> 8);
+        header[1] = (char) (current_size);
+        BoltBuffer_load(tx_buffer, &header[0], sizeof(header));
+        BoltBuffer_load(tx_buffer, BoltBuffer_unload_pointer(msg_buffer, current_size), current_size);
+        total_remaining -= current_size;
+    }
+
+    header[0] = (char) (0);
+    header[1] = (char) (0);
+    BoltBuffer_load(tx_buffer, &header[0], sizeof(header));
+    BoltBuffer_compact(msg_buffer);
+}

--- a/seabolt/src/bolt/protocol/protocol.h
+++ b/seabolt/src/bolt/protocol/protocol.h
@@ -145,10 +145,12 @@ struct BoltMessage* BoltMessage_create(int8_t code, int32_t n_fields);
 
 void BoltMessage_destroy(struct BoltMessage* message);
 
+struct BoltValue* BoltMessage_param(struct BoltMessage* message, int32_t index);
+
 int
 write_message(struct BoltMessage* message, check_struct_signature_func check_writable, struct BoltBuffer* buffer,
         const struct BoltLog* log);
 
-int push_to_transmission(struct BoltBuffer* msg_buffer, struct BoltBuffer* tx_buffer);
+void push_to_transmission(struct BoltBuffer* msg_buffer, struct BoltBuffer* tx_buffer);
 
 #endif //SEABOLT_ALL_PROTOCOL_H

--- a/seabolt/src/bolt/protocol/protocol.h
+++ b/seabolt/src/bolt/protocol/protocol.h
@@ -21,7 +21,134 @@
 #define SEABOLT_ALL_PROTOCOL_H
 
 #include "bolt/config.h"
+#include "packstream.h"
 
-typedef int (*check_struct_signature_func)(int16_t);
+#define FETCH_ERROR -1
+#define FETCH_SUMMARY 0
+#define FETCH_RECORD 1
+
+struct BoltProtocol;
+
+struct BoltConnection;
+
+typedef int (* bool_func)(struct BoltConnection*);
+
+typedef struct BoltValue* (* bolt_value_func)(struct BoltConnection*);
+
+typedef char* (* char_func)(struct BoltConnection*);
+
+typedef int16_t (* short_func)(struct BoltConnection*);
+
+typedef const char* (* short_return_char_func)(int16_t);
+
+typedef int (* init_func)(struct BoltConnection*, const char*, const struct BoltValue*);
+
+typedef int (* goodbye_func)(struct BoltConnection*);
+
+typedef int (* clear_begin_tx_func)(struct BoltConnection*);
+
+typedef int (* set_begin_tx_bookmark_func)(struct BoltConnection*, struct BoltValue*);
+
+typedef int (* set_begin_tx_metadata_func)(struct BoltConnection*, struct BoltValue*);
+
+typedef int (* set_begin_tx_timeout_func)(struct BoltConnection*, int32_t);
+
+typedef int (* load_begin_tx_func)(struct BoltConnection*);
+
+typedef int (* load_commit_tx_func)(struct BoltConnection*);
+
+typedef int (* load_rollback_tx_func)(struct BoltConnection*);
+
+typedef int (* clear_run_func)(struct BoltConnection*);
+
+typedef int (* set_run_bookmark_func)(struct BoltConnection*, struct BoltValue*);
+
+typedef int (* set_run_tx_metadata_func)(struct BoltConnection*, struct BoltValue*);
+
+typedef int (* set_run_tx_timeout_func)(struct BoltConnection*, int32_t);
+
+typedef int (* set_run_cypher_func)(struct BoltConnection*, const char*, const size_t, int32_t);
+
+typedef struct BoltValue* (* set_run_cypher_parameter_func)(struct BoltConnection*, int32_t, const char*, size_t);
+
+typedef int (* load_run_func)(struct BoltConnection*);
+
+typedef int (* load_discard_func)(struct BoltConnection*, int32_t);
+
+typedef int (* load_pull_func)(struct BoltConnection*, int32_t);
+
+typedef int (* load_reset_func)(struct BoltConnection*);
+
+typedef bolt_request (* last_request_func)(struct BoltConnection*);
+
+typedef int (* fetch_func)(struct BoltConnection*, bolt_request);
+
+struct BoltProtocol {
+    void* proto_state;
+
+    short_return_char_func message_name;
+    short_return_char_func structure_name;
+
+    check_struct_signature_func check_readable_struct;
+    check_struct_signature_func check_writable_struct;
+
+    init_func init;
+    goodbye_func goodbye;
+
+    clear_begin_tx_func clear_begin_tx;
+    set_begin_tx_bookmark_func set_begin_tx_bookmark;
+    set_begin_tx_metadata_func set_begin_tx_metadata;
+    set_begin_tx_timeout_func set_begin_tx_timeout;
+    load_begin_tx_func load_begin_tx;
+
+    load_commit_tx_func load_commit_tx;
+
+    load_rollback_tx_func load_rollback_tx;
+
+    clear_run_func clear_run;
+    set_run_bookmark_func set_run_bookmark;
+    set_run_tx_timeout_func set_run_tx_timeout;
+    set_run_tx_metadata_func set_run_tx_metadata;
+    set_run_cypher_func set_run_cypher;
+    set_run_cypher_parameter_func set_run_cypher_parameter;
+    load_run_func load_run;
+
+    load_discard_func load_discard;
+    load_pull_func load_pull;
+
+    load_reset_func load_reset;
+
+    last_request_func last_request;
+
+    bolt_value_func field_names;
+    bolt_value_func field_values;
+    bolt_value_func metadata;
+    bolt_value_func failure;
+
+    bool_func is_success_summary;
+    bool_func is_failure_summary;
+    bool_func is_ignored_summary;
+
+    short_func last_data_type;
+    char_func last_bookmark;
+    char_func server;
+
+    fetch_func fetch;
+};
+
+struct BoltMessage {
+    int8_t code;
+    struct BoltValue* fields;
+};
+
+struct BoltMessage* BoltMessage_create(int8_t code, int32_t n_fields);
+
+void BoltMessage_destroy(struct BoltMessage* message);
+
+int
+write_message(struct BoltMessage* message, check_struct_signature_func check_writable, struct BoltBuffer* buffer,
+        const struct BoltLog* log);
+
+int push_to_transmission(struct BoltBuffer* msg_buffer, struct BoltBuffer* tx_buffer);
 
 #endif //SEABOLT_ALL_PROTOCOL_H

--- a/seabolt/src/bolt/protocol/protocol.h
+++ b/seabolt/src/bolt/protocol/protocol.h
@@ -51,7 +51,7 @@ typedef int (* set_begin_tx_bookmark_func)(struct BoltConnection*, struct BoltVa
 
 typedef int (* set_begin_tx_metadata_func)(struct BoltConnection*, struct BoltValue*);
 
-typedef int (* set_begin_tx_timeout_func)(struct BoltConnection*, int32_t);
+typedef int (* set_begin_tx_timeout_func)(struct BoltConnection*, int64_t);
 
 typedef int (* load_begin_tx_func)(struct BoltConnection*);
 
@@ -65,7 +65,7 @@ typedef int (* set_run_bookmark_func)(struct BoltConnection*, struct BoltValue*)
 
 typedef int (* set_run_tx_metadata_func)(struct BoltConnection*, struct BoltValue*);
 
-typedef int (* set_run_tx_timeout_func)(struct BoltConnection*, int32_t);
+typedef int (* set_run_tx_timeout_func)(struct BoltConnection*, int64_t);
 
 typedef int (* set_run_cypher_func)(struct BoltConnection*, const char*, const size_t, int32_t);
 

--- a/seabolt/src/bolt/protocol/v1.c
+++ b/seabolt/src/bolt/protocol/v1.c
@@ -54,22 +54,6 @@
 
 #define TRY(code) { int status_try = (code); if (status_try != BOLT_SUCCESS) { return status_try; } }
 
-struct BoltMessage* BoltMessage_create(int8_t code, int32_t n_fields)
-{
-    const size_t size = sizeof(struct BoltMessage);
-    struct BoltMessage* message = BoltMem_allocate(size);
-    message->code = code;
-    message->fields = BoltValue_create();
-    BoltValue_format_as_List(message->fields, n_fields);
-    return message;
-}
-
-void BoltMessage_destroy(struct BoltMessage* message)
-{
-    BoltValue_destroy(message->fields);
-    BoltMem_deallocate(message, sizeof(struct BoltMessage));
-}
-
 int BoltProtocolV1_compile_INIT(struct BoltMessage* message, const char* user_agent, const struct BoltValue* auth_token,
         int mask_secure_fields)
 {
@@ -129,12 +113,349 @@ int BoltProtocolV1_check_writable_struct_signature(int16_t signature)
     return 0;
 }
 
+const char* BoltProtocolV1_structure_name(int16_t code)
+{
+    switch (code) {
+    case 'N':
+        return "Node";
+    case 'R':
+        return "Relationship";
+    case 'r':
+        return "UnboundRelationship";
+    case 'P':
+        return "Path";
+    default:
+        return "?";
+    }
+}
+
+const char* BoltProtocolV1_message_name(int16_t code)
+{
+    switch (code) {
+    case 0x01:
+        return "INIT";
+    case 0x0E:
+        return "ACK_FAILURE";
+    case 0x0F:
+        return "RESET";
+    case 0x10:
+        return "RUN";
+    case 0x2F:
+        return "DISCARD_ALL";
+    case 0x3F:
+        return "PULL_ALL";
+    case 0x70:
+        return "SUCCESS";
+    case 0x71:
+        return "RECORD";
+    case 0x7E:
+        return "IGNORED";
+    case 0x7F:
+        return "FAILURE";
+    default:
+        return NULL;
+    }
+}
+
+struct BoltProtocolV1State* BoltProtocolV1_state(struct BoltConnection* connection)
+{
+    return (struct BoltProtocolV1State*) (connection->protocol->proto_state);
+}
+
+void ensure_failure_data(struct BoltProtocolV1State* state)
+{
+    if (state->failure_data==NULL) {
+        state->failure_data = BoltValue_create();
+        BoltValue_format_as_Dictionary(state->failure_data, 2);
+        BoltDictionary_set_key(state->failure_data, 0, "code", strlen("code"));
+        BoltDictionary_set_key(state->failure_data, 1, "message", strlen("message"));
+    }
+}
+
+void clear_failure_data(struct BoltProtocolV1State* state)
+{
+    if (state->failure_data!=NULL) {
+        BoltValue_destroy(state->failure_data);
+        state->failure_data = NULL;
+    }
+}
+
+void BoltProtocolV1_clear_failure(struct BoltConnection* connection)
+{
+    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
+    clear_failure_data(state);
+}
+
+int BoltProtocolV1_load_message(struct BoltConnection* connection, struct BoltMessage* message, int quiet)
+{
+    if (!quiet) {
+        struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
+        BoltLog_message(connection->log, "C", state->next_request_id, message->code, message->fields,
+                connection->protocol->structure_name, connection->protocol->message_name);
+    }
+
+    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
+    int prev_cursor = state->tx_buffer->cursor;
+    int prev_extent = state->tx_buffer->extent;
+    int status = write_message(message, connection->protocol->check_writable_struct, state->tx_buffer, connection->log);
+    if (status==BOLT_SUCCESS) {
+        push_to_transmission(state->tx_buffer, connection->tx_buffer);
+        state->next_request_id += 1;
+    }
+    else {
+        // Reset buffer to its previous state
+        state->tx_buffer->cursor = prev_cursor;
+        state->tx_buffer->extent = prev_extent;
+    }
+    return status;
+}
+
+int BoltProtocolV1_init(struct BoltConnection* connection, const char* user_agent, const struct BoltValue* auth_token)
+{
+    struct BoltMessage* init = BoltMessage_create(INIT, 2);
+    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
+    TRY(BoltProtocolV1_compile_INIT(init, user_agent, auth_token, 1));
+    BoltLog_message(connection->log, "C", state->next_request_id, init->code, init->fields,
+            connection->protocol->structure_name, connection->protocol->message_name);
+    TRY(BoltProtocolV1_compile_INIT(init, user_agent, auth_token, 0));
+    TRY(BoltProtocolV1_load_message(connection, init, 1));
+    bolt_request init_request = BoltConnection_last_request(connection);
+    BoltMessage_destroy(init);
+    TRY(BoltConnection_send(connection));
+    TRY(BoltConnection_fetch_summary(connection, init_request));
+    return state->data_type;
+}
+
+int BoltProtocolV1_load_discard_request(struct BoltConnection* connection, int32_t n)
+{
+    if (n>=0) {
+        return BOLT_PROTOCOL_VIOLATION;
+    }
+    else {
+        struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
+        TRY(BoltProtocolV1_load_message(connection, state->discard_request, 0));
+        return BOLT_SUCCESS;
+    }
+}
+
+int BoltProtocolV1_load_pull_request(struct BoltConnection* connection, int32_t n)
+{
+    if (n>=0) {
+        return BOLT_PROTOCOL_VIOLATION;
+    }
+    else {
+        struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
+        TRY(BoltProtocolV1_load_message(connection, state->pull_request, 0));
+        return BOLT_SUCCESS;
+    }
+}
+
+int BoltProtocolV1_load_reset_request(struct BoltConnection* connection)
+{
+    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
+    TRY(BoltProtocolV1_load_message(connection, state->reset_request, 0));
+    BoltProtocolV1_clear_failure(connection);
+    return BOLT_SUCCESS;
+}
+
+int BoltProtocolV1_clear_load_run_request(struct BoltConnection* connection)
+{
+    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
+    BoltValue_format_as_Null(state->run.statement);
+    BoltValue_format_as_Dictionary(state->run.parameters, 0);
+}
+
+int BoltProtocolV1_set_run_cypher(struct BoltConnection* connection, const char* cypher, const size_t cypher_size,
+        int32_t n_parameter)
+{
+    if (cypher_size<=INT32_MAX) {
+        struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
+        BoltValue_format_as_String(state->run.statement, cypher, (int32_t) (cypher_size));
+        BoltValue_format_as_Dictionary(state->run.parameters, n_parameter);
+        return BOLT_SUCCESS;
+    }
+
+    return BOLT_PROTOCOL_VIOLATION;
+}
+
+struct BoltValue* BoltProtocolV1_set_run_cypher_parameter(struct BoltConnection* connection, int32_t index,
+        const char* name, size_t name_size)
+{
+    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
+    BoltDictionary_set_key(state->run.parameters, index, name, name_size);
+    return BoltDictionary_value(state->run.parameters, index);
+}
+
+int BoltProtocolV1_load_run_request(struct BoltConnection* connection)
+{
+    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
+    TRY(BoltProtocolV1_load_message(connection, state->run.request, 0));
+    return BOLT_SUCCESS;
+}
+
+int BoltProtocolV1_clear_load_begin_tx_request(struct BoltConnection* connection)
+{
+    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
+    BoltValue_format_as_Dictionary(state->begin.parameters, 0);
+}
+
+int BoltProtocolV1_set_begin_tx_bookmark(struct BoltConnection* connection, struct BoltValue* bookmark_list)
+{
+    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
+
+    if (bookmark_list==NULL) {
+        BoltValue_format_as_Dictionary(state->begin.parameters, 0);
+        return BOLT_SUCCESS;
+    }
+
+    if (BoltValue_type(bookmark_list)!=BOLT_LIST) {
+        return BOLT_PROTOCOL_VIOLATION;
+    }
+
+    for (int32_t i = 0; i<bookmark_list->size; i++) {
+        struct BoltValue* element = BoltList_value(bookmark_list, i);
+
+        if (BoltValue_type(element)!=BOLT_STRING) {
+            return BOLT_PROTOCOL_VIOLATION;
+        }
+
+        if (element->size>INT32_MAX) {
+            return BOLT_PROTOCOL_VIOLATION;
+        }
+    }
+
+    struct BoltValue* bookmarks;
+    if (state->begin.parameters->size==0) {
+        BoltValue_format_as_Dictionary(state->begin.parameters, 1);
+        if (BoltDictionary_set_key(state->begin.parameters, 0, "bookmarks", 9)) {
+            return BOLT_PROTOCOL_VIOLATION;
+        }
+        bookmarks = BoltDictionary_value(state->begin.parameters, 0);
+    }
+    else {
+        bookmarks = BoltDictionary_value(state->begin.parameters, 0);
+    }
+
+    BoltValue_copy(bookmarks, bookmark_list);
+
+    return BOLT_SUCCESS;
+}
+
+int BoltProtocolV1_load_begin_request(struct BoltConnection* connection)
+{
+    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
+    TRY(BoltProtocolV1_load_message(connection, state->begin.request, 0));
+    TRY(BoltProtocolV1_load_message(connection, state->discard_request, 0));
+    return BOLT_SUCCESS;
+}
+
+int BoltProtocolV1_load_commit_request(struct BoltConnection* connection)
+{
+    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
+    TRY(BoltProtocolV1_load_message(connection, state->commit.request, 0));
+    TRY(BoltProtocolV1_load_message(connection, state->discard_request, 0));
+    return BOLT_SUCCESS;
+}
+
+int BoltProtocolV1_load_rollback_request(struct BoltConnection* connection)
+{
+    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
+    TRY(BoltProtocolV1_load_message(connection, state->rollback.request, 0));
+    TRY(BoltProtocolV1_load_message(connection, state->discard_request, 0));
+    return BOLT_SUCCESS;
+}
+
+struct BoltValue* BoltProtocolV1_result_field_names(struct BoltConnection* connection)
+{
+    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
+    switch (BoltValue_type(state->result_field_names)) {
+    case BOLT_LIST:
+        return state->result_field_names;
+    default:
+        return NULL;
+    }
+}
+
+struct BoltValue* BoltProtocolV1_result_field_values(struct BoltConnection* connection)
+{
+    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
+    switch (state->data_type) {
+    case BOLT_V1_RECORD:
+        switch (BoltValue_type(state->data)) {
+        case BOLT_LIST: {
+            struct BoltValue* values = BoltList_value(state->data, 0);
+            return values;
+        }
+        default:
+            return NULL;
+        }
+    default:
+        return NULL;
+    }
+}
+
+struct BoltValue* BoltProtocolV1_result_metadata(struct BoltConnection* connection)
+{
+    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
+    switch (BoltValue_type(state->result_metadata)) {
+    case BOLT_DICTIONARY:
+        return state->result_metadata;
+    default:
+        return NULL;
+    }
+}
+
+struct BoltValue* BoltProtocolV1_failure(struct BoltConnection* connection)
+{
+    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
+    return state->failure_data;
+}
+
+char* BoltProtocolV1_last_bookmark(struct BoltConnection* connection)
+{
+    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
+    return state->last_bookmark;
+}
+
+char* BoltProtocolV1_server(struct BoltConnection* connection)
+{
+    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
+    return state->server;
+}
+
+bolt_request BoltProtocolV1_last_request(struct BoltConnection* connection)
+{
+    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
+    return state->next_request_id-1;
+}
+
+int BoltProtocolV1_is_success_summary(struct BoltConnection* connection)
+{
+    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
+    return state->data_type==BOLT_V1_SUCCESS;
+}
+
+int BoltProtocolV1_is_failure_summary(struct BoltConnection* connection)
+{
+    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
+    return state->data_type==BOLT_V1_FAILURE;
+}
+
+int BoltProtocolV1_is_ignored_summary(struct BoltConnection* connection)
+{
+    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
+    return state->data_type==BOLT_V1_IGNORED;
+}
+
+int16_t BoltProtocolV1_last_data_type(struct BoltConnection* connection)
+{
+    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
+    return state->data_type;
+}
+
 struct BoltProtocolV1State* BoltProtocolV1_create_state()
 {
     struct BoltProtocolV1State* state = BoltMem_allocate(sizeof(struct BoltProtocolV1State));
-
-    state->check_readable_struct = &BoltProtocolV1_check_readable_struct_signature;
-    state->check_writable_struct = &BoltProtocolV1_check_writable_struct_signature;
 
     state->tx_buffer = BoltBuffer_create(INITIAL_TX_BUFFER_SIZE);
     state->rx_buffer = BoltBuffer_create(INITIAL_RX_BUFFER_SIZE);
@@ -200,105 +521,170 @@ void BoltProtocolV1_destroy_state(struct BoltProtocolV1State* state)
     BoltMem_deallocate(state, sizeof(struct BoltProtocolV1State));
 }
 
-struct BoltProtocolV1State* BoltProtocolV1_state(struct BoltConnection* connection)
-{
-    return (struct BoltProtocolV1State*) (connection->protocol_state);
-}
-
-/**
- * Copy request data from buffer 1 to buffer 0, also adding chunks.
- *
- * @param connection
- */
-void enqueue(struct BoltConnection* connection);
-
-int load_message(struct BoltConnection* connection, struct BoltMessage* message)
+int BoltProtocolV1_unload(struct BoltConnection* connection)
 {
     struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
-    if (state->check_writable_struct(message->code)) {
-        TRY(load_structure_header(state->tx_buffer, message->code, (int8_t) (message->fields->size)));
-        for (int32_t i = 0; i<message->fields->size; i++) {
-            TRY(load(state->check_writable_struct, state->tx_buffer, BoltList_value(message->fields, i),
-                    connection->log));
+    if (BoltBuffer_unloadable(state->rx_buffer)==0) {
+        return 0;
+    }
+
+    uint8_t marker;
+    TRY(BoltBuffer_unload_u8(state->rx_buffer, &marker));
+    if (marker_type(marker)!=PACKSTREAM_STRUCTURE) {
+        return BOLT_PROTOCOL_VIOLATION;
+    }
+
+    uint8_t code;
+    TRY(BoltBuffer_unload_u8(state->rx_buffer, &code));
+    state->data_type = code;
+
+    int32_t size = marker & 0x0F;
+    BoltValue_format_as_List(state->data, size);
+    for (int i = 0; i<size; i++) {
+        TRY(unload(connection->protocol->check_readable_struct, state->rx_buffer, BoltList_value(state->data, i),
+                connection->log));
+    }
+    if (code==BOLT_V1_RECORD) {
+        if (state->record_counter<MAX_LOGGED_RECORDS) {
+            BoltLog_message(connection->log, "S", state->response_counter, code, state->data,
+                    connection->protocol->structure_name, connection->protocol->message_name);
         }
-        enqueue(connection);
-        return BOLT_SUCCESS;
+        state->record_counter += 1;
     }
-    return BOLT_PROTOCOL_UNSUPPORTED_TYPE;
+    else {
+        if (state->record_counter>MAX_LOGGED_RECORDS) {
+            BoltLog_info(connection->log, "S[%d]: Received %llu more records", state->response_counter,
+                    state->record_counter-MAX_LOGGED_RECORDS);
+        }
+        state->record_counter = 0;
+        BoltLog_message(connection->log, "S", state->response_counter, code, state->data,
+                connection->protocol->structure_name, connection->protocol->message_name);
+    }
+    return BOLT_SUCCESS;
 }
 
-int BoltProtocolV1_load_message(struct BoltConnection* connection, struct BoltMessage* message, int quiet)
-{
-    if (!quiet) {
-        struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
-        BoltLog_message(connection->log, "C", state->next_request_id, message->code, message->fields,
-                connection->protocol_version);
-    }
-
-    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
-    int prev_cursor = state->tx_buffer->cursor;
-    int prev_extent = state->tx_buffer->extent;
-    int status = load_message(connection, message);
-    if (status!=BOLT_SUCCESS) {
-        // Reset buffer to its previous state
-        state->tx_buffer->cursor = prev_cursor;
-        state->tx_buffer->extent = prev_extent;
-    }
-    return status;
-}
-
-/**
- * Copy request data from buffer 1 to buffer 0, also adding chunks.
- *
- * @param connection
- * @return request ID
- */
-void enqueue(struct BoltConnection* connection)
+void BoltProtocolV1_extract_metadata(struct BoltConnection* connection, struct BoltValue* metadata)
 {
     struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
 
-    // loop through data, generate several chunks if it's larger than max chunk size
-    int total_size = BoltBuffer_unloadable(state->tx_buffer);
-    int total_remaining = total_size;
-    char header[2];
-    while (total_remaining>0) {
-        int current_size = total_remaining>BOLT_MAX_CHUNK_SIZE ? BOLT_MAX_CHUNK_SIZE : total_remaining;
-        header[0] = (char) (current_size >> 8);
-        header[1] = (char) (current_size);
-        BoltBuffer_load(connection->tx_buffer, &header[0], sizeof(header));
-        BoltBuffer_load(connection->tx_buffer, BoltBuffer_unload_pointer(state->tx_buffer, current_size), current_size);
-        total_remaining -= current_size;
-    }
+    switch (BoltValue_type(metadata)) {
+    case BOLT_DICTIONARY: {
+        for (int32_t i = 0; i<metadata->size; i++) {
+            struct BoltValue* key = BoltDictionary_key(metadata, i);
 
-    header[0] = (char) (0);
-    header[1] = (char) (0);
-    BoltBuffer_load(connection->tx_buffer, &header[0], sizeof(header));
-    BoltBuffer_compact(state->tx_buffer);
-    state->next_request_id += 1;
+            if (BoltString_equals(key, "bookmark")) {
+                struct BoltValue* value = BoltDictionary_value(metadata, i);
+                switch (BoltValue_type(value)) {
+                case BOLT_STRING: {
+                    memset(state->last_bookmark, 0, MAX_BOOKMARK_SIZE);
+                    memcpy(state->last_bookmark, BoltString_get(value), (size_t) (value->size));
+                    BoltLog_info(connection->log, "<SET last_bookmark=\"%s\">", state->last_bookmark);
+                    break;
+                }
+                default:
+                    break;
+                }
+            }
+            else if (BoltString_equals(key, "fields")) {
+                struct BoltValue* value = BoltDictionary_value(metadata, i);
+                switch (BoltValue_type(value)) {
+                case BOLT_LIST: {
+                    struct BoltValue* target_value = state->result_field_names;
+                    BoltValue_format_as_List(target_value, value->size);
+                    for (int j = 0; j<value->size; j++) {
+                        struct BoltValue* source_value = BoltList_value(value, j);
+                        switch (BoltValue_type(source_value)) {
+                        case BOLT_STRING:
+                            BoltValue_format_as_String(BoltList_value(target_value, j),
+                                    BoltString_get(source_value), source_value->size);
+                            break;
+                        default:
+                            BoltValue_format_as_Null(BoltList_value(target_value, j));
+                        }
+                    }
+                    BoltLog_value(connection->log, "<SET result_field_names=%s>", target_value,
+                            connection->protocol->structure_name);
+                    break;
+                }
+                default:
+                    break;
+                }
+            }
+            else if (BoltString_equals(key, "server")) {
+                struct BoltValue* value = BoltDictionary_value(metadata, i);
+                switch (BoltValue_type(value)) {
+                case BOLT_STRING: {
+                    memset(state->server, 0, MAX_SERVER_SIZE);
+                    memcpy(state->server, BoltString_get(value), (size_t) (value->size));
+                    BoltLog_info(connection->log, "<SET server=\"%s\">", state->server);
+                    break;
+                }
+                default:
+                    break;
+                }
+            }
+            else if (BoltString_equals(key, "code") && state->data_type==BOLT_V1_FAILURE) {
+                struct BoltValue* value = BoltDictionary_value(metadata, i);
+                switch (BoltValue_type(value)) {
+                case BOLT_STRING: {
+                    ensure_failure_data(state);
+
+                    struct BoltValue* target_value = BoltDictionary_value(state->failure_data, 0);
+                    BoltValue_format_as_String(target_value, BoltString_get(value), value->size);
+
+                    BoltLog_value(connection->log, "<FAILURE code=\"%s\">", target_value,
+                            connection->protocol->structure_name);
+
+                    break;
+                }
+                default:
+                    break;
+                }
+            }
+            else if (BoltString_equals(key, "message") && state->data_type==BOLT_V1_FAILURE) {
+                struct BoltValue* value = BoltDictionary_value(metadata, i);
+                switch (BoltValue_type(value)) {
+                case BOLT_STRING: {
+                    ensure_failure_data(state);
+
+                    struct BoltValue* target_value = BoltDictionary_value(state->failure_data, 1);
+                    BoltValue_format_as_String(target_value, BoltString_get(value), value->size);
+
+                    BoltLog_value(connection->log, "<FAILURE message=\"%s\">", target_value,
+                            connection->protocol->structure_name);
+
+                    break;
+                }
+                default:
+                    break;
+                }
+            }
+            else {
+                struct BoltValue* source_key = BoltDictionary_key(metadata, i);
+                struct BoltValue* source_value = BoltDictionary_value(metadata, i);
+
+                // increase length
+                int32_t index = state->result_metadata->size;
+                BoltValue_format_as_Dictionary(state->result_metadata, index+1);
+
+                struct BoltValue* dest_key = BoltDictionary_key(state->result_metadata, index);
+                struct BoltValue* dest_value = BoltDictionary_value(state->result_metadata, index);
+
+                BoltValue_copy(dest_key, source_key);
+                BoltValue_copy(dest_value, source_value);
+            }
+        }
+        break;
+    }
+    default:
+        break;
+    }
 }
 
-void ensure_failure_data(struct BoltProtocolV1State* state)
-{
-    if (state->failure_data==NULL) {
-        state->failure_data = BoltValue_create();
-        BoltValue_format_as_Dictionary(state->failure_data, 2);
-        BoltDictionary_set_key(state->failure_data, 0, "code", strlen("code"));
-        BoltDictionary_set_key(state->failure_data, 1, "message", strlen("message"));
-    }
-}
-
-void clear_failure_data(struct BoltProtocolV1State* state)
-{
-    if (state->failure_data!=NULL) {
-        BoltValue_destroy(state->failure_data);
-        state->failure_data = NULL;
-    }
-}
-
-int BoltProtocolV1_fetch(struct BoltConnection* connection, bolt_request_t request_id)
+int BoltProtocolV1_fetch(struct BoltConnection* connection, bolt_request request_id)
 {
     struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
-    bolt_request_t response_id;
+    bolt_request response_id;
     do {
         char header[2];
         int status = BoltConnection_receive(connection, &header[0], 2);
@@ -344,361 +730,86 @@ int BoltProtocolV1_fetch(struct BoltConnection* connection, bolt_request_t reque
     return 1;
 }
 
-int BoltProtocolV1_unload(struct BoltConnection* connection)
+int BoltProtocolV1_set_tx_timeout_unsupported(struct BoltConnection* connection, int32_t n)
 {
-    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
-    if (BoltBuffer_unloadable(state->rx_buffer)==0) {
-        return 0;
-    }
+    return BOLT_PROTOCOL_UNSUPPORTED;
+}
 
-    uint8_t marker;
-    TRY(BoltBuffer_unload_u8(state->rx_buffer, &marker));
-    if (marker_type(marker)!=PACKSTREAM_STRUCTURE) {
-        return BOLT_PROTOCOL_VIOLATION;
-    }
+int BoltProtocolV1_set_tx_bookmark_unsupported(struct BoltConnection* connection, struct BoltValue* value)
+{
+    return BOLT_PROTOCOL_UNSUPPORTED;
+}
 
-    uint8_t code;
-    TRY(BoltBuffer_unload_u8(state->rx_buffer, &code));
-    state->data_type = code;
+int BoltProtocolV1_set_tx_metadata_unsupported(struct BoltConnection* connection, struct BoltValue* value)
+{
+    return BOLT_PROTOCOL_UNSUPPORTED;
+}
 
-    int32_t size = marker & 0x0F;
-    BoltValue_format_as_List(state->data, size);
-    for (int i = 0; i<size; i++) {
-        TRY(unload(state->check_readable_struct, state->rx_buffer, BoltList_value(state->data, i),
-                connection->log));
-    }
-    if (code==BOLT_V1_RECORD) {
-        if (state->record_counter<MAX_LOGGED_RECORDS) {
-            BoltLog_message(connection->log, "S", state->response_counter, code, state->data,
-                    connection->protocol_version);
-        }
-        state->record_counter += 1;
-    }
-    else {
-        if (state->record_counter>MAX_LOGGED_RECORDS) {
-            BoltLog_info(connection->log, "S[%d]: Received %llu more records", state->response_counter,
-                    state->record_counter-MAX_LOGGED_RECORDS);
-        }
-        state->record_counter = 0;
-        BoltLog_message(connection->log, "S", state->response_counter, code, state->data, connection->protocol_version);
-    }
+int BoltProtocolV1_goodbye_noop(struct BoltConnection* connection)
+{
     return BOLT_SUCCESS;
 }
 
-const char* BoltProtocolV1_structure_name(int16_t code)
+struct BoltProtocol* BoltProtocolV1_create_protocol()
 {
-    switch (code) {
-    case 'N':
-        return "Node";
-    case 'R':
-        return "Relationship";
-    case 'r':
-        return "UnboundRelationship";
-    case 'P':
-        return "Path";
-    default:
-        return "?";
+    struct BoltProtocol* protocol = BoltMem_allocate(sizeof(struct BoltProtocol));
+
+    protocol->proto_state = BoltProtocolV1_create_state();
+
+    protocol->message_name = &BoltProtocolV1_message_name;
+    protocol->structure_name = &BoltProtocolV1_structure_name;
+
+    protocol->check_readable_struct = &BoltProtocolV1_check_readable_struct_signature;
+    protocol->check_writable_struct = &BoltProtocolV1_check_writable_struct_signature;
+
+    protocol->init = &BoltProtocolV1_init;
+    protocol->goodbye = &BoltProtocolV1_goodbye_noop;
+
+    protocol->clear_run = &BoltProtocolV1_clear_load_run_request;
+    protocol->set_run_cypher = &BoltProtocolV1_set_run_cypher;
+    protocol->set_run_cypher_parameter = &BoltProtocolV1_set_run_cypher_parameter;
+    protocol->set_run_bookmark = &BoltProtocolV1_set_tx_bookmark_unsupported;
+    protocol->set_run_tx_timeout = &BoltProtocolV1_set_tx_timeout_unsupported;
+    protocol->set_run_tx_metadata = &BoltProtocolV1_set_tx_metadata_unsupported;
+    protocol->load_run = &BoltProtocolV1_load_run_request;
+
+    protocol->clear_begin_tx = &BoltProtocolV1_clear_load_begin_tx_request;
+    protocol->set_begin_tx_bookmark = &BoltProtocolV1_set_begin_tx_bookmark;
+    protocol->set_begin_tx_timeout = &BoltProtocolV1_set_tx_timeout_unsupported;
+    protocol->set_begin_tx_metadata = &BoltProtocolV1_set_tx_metadata_unsupported;
+    protocol->load_begin_tx = &BoltProtocolV1_load_begin_request;
+
+    protocol->load_commit_tx = &BoltProtocolV1_load_commit_request;
+    protocol->load_rollback_tx = &BoltProtocolV1_load_rollback_request;
+    protocol->load_discard = &BoltProtocolV1_load_discard_request;
+    protocol->load_pull = &BoltProtocolV1_load_pull_request;
+    protocol->load_reset = &BoltProtocolV1_load_reset_request;
+
+    protocol->last_request = &BoltProtocolV1_last_request;
+
+    protocol->field_names = &BoltProtocolV1_result_field_names;
+    protocol->field_values = &BoltProtocolV1_result_field_values;
+    protocol->metadata = &BoltProtocolV1_result_metadata;
+    protocol->failure = &BoltProtocolV1_failure;
+
+    protocol->last_data_type = &BoltProtocolV1_last_data_type;
+    protocol->last_bookmark = &BoltProtocolV1_last_bookmark;
+    protocol->server = &BoltProtocolV1_server;
+
+    protocol->is_failure_summary = &BoltProtocolV1_is_failure_summary;
+    protocol->is_success_summary = &BoltProtocolV1_is_success_summary;
+    protocol->is_ignored_summary = &BoltProtocolV1_is_ignored_summary;
+
+    protocol->fetch = &BoltProtocolV1_fetch;
+
+    return protocol;
+}
+
+void BoltProtocolV1_destroy_protocol(struct BoltProtocol* protocol)
+{
+    if (protocol!=NULL) {
+        BoltProtocolV1_destroy_state(protocol->proto_state);
     }
-}
 
-const char* BoltProtocolV1_message_name(int16_t code)
-{
-    switch (code) {
-    case 0x01:
-        return "INIT";
-    case 0x0E:
-        return "ACK_FAILURE";
-    case 0x0F:
-        return "RESET";
-    case 0x10:
-        return "RUN";
-    case 0x2F:
-        return "DISCARD_ALL";
-    case 0x3F:
-        return "PULL_ALL";
-    case 0x70:
-        return "SUCCESS";
-    case 0x71:
-        return "RECORD";
-    case 0x7E:
-        return "IGNORED";
-    case 0x7F:
-        return "FAILURE";
-    default:
-        return NULL;
-    }
-}
-
-int BoltProtocolV1_init(struct BoltConnection* connection, const char* user_agent, const struct BoltValue* auth_token)
-{
-    struct BoltMessage* init = BoltMessage_create(INIT, 2);
-    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
-    TRY(BoltProtocolV1_compile_INIT(init, user_agent, auth_token, 1));
-    BoltLog_message(connection->log, "C", state->next_request_id, init->code, init->fields, connection->protocol_version);
-    TRY(BoltProtocolV1_compile_INIT(init, user_agent, auth_token, 0));
-    TRY(BoltProtocolV1_load_message(connection, init, 1));
-    bolt_request_t init_request = BoltConnection_last_request(connection);
-    BoltMessage_destroy(init);
-    TRY(BoltConnection_send(connection));
-    TRY(BoltConnection_fetch_summary(connection, init_request));
-    return state->data_type;
-}
-
-void BoltProtocolV1_clear_failure(struct BoltConnection* connection)
-{
-    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
-    clear_failure_data(state);
-}
-
-void BoltProtocolV1_extract_metadata(struct BoltConnection* connection, struct BoltValue* metadata)
-{
-    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
-
-    switch (BoltValue_type(metadata)) {
-    case BOLT_DICTIONARY: {
-        for (int32_t i = 0; i<metadata->size; i++) {
-            struct BoltValue* key = BoltDictionary_key(metadata, i);
-
-            if (BoltString_equals(key, "bookmark")) {
-                struct BoltValue* value = BoltDictionary_value(metadata, i);
-                switch (BoltValue_type(value)) {
-                case BOLT_STRING: {
-                    memset(state->last_bookmark, 0, MAX_BOOKMARK_SIZE);
-                    memcpy(state->last_bookmark, BoltString_get(value), (size_t) (value->size));
-                    BoltLog_info(connection->log, "<SET last_bookmark=\"%s\">", state->last_bookmark);
-                    break;
-                }
-                default:
-                    break;
-                }
-            }
-            else if (BoltString_equals(key, "fields")) {
-                struct BoltValue* value = BoltDictionary_value(metadata, i);
-                switch (BoltValue_type(value)) {
-                case BOLT_LIST: {
-                    struct BoltValue* target_value = state->result_field_names;
-                    BoltValue_format_as_List(target_value, value->size);
-                    for (int j = 0; j<value->size; j++) {
-                        struct BoltValue* source_value = BoltList_value(value, j);
-                        switch (BoltValue_type(source_value)) {
-                        case BOLT_STRING:
-                            BoltValue_format_as_String(BoltList_value(target_value, j),
-                                    BoltString_get(source_value), source_value->size);
-                            break;
-                        default:
-                            BoltValue_format_as_Null(BoltList_value(target_value, j));
-                        }
-                    }
-                    BoltLog_value(connection->log, "<SET result_field_names=%s>", target_value,
-                            connection->protocol_version);
-                    break;
-                }
-                default:
-                    break;
-                }
-            }
-            else if (BoltString_equals(key, "server")) {
-                struct BoltValue* value = BoltDictionary_value(metadata, i);
-                switch (BoltValue_type(value)) {
-                case BOLT_STRING: {
-                    memset(state->server, 0, MAX_SERVER_SIZE);
-                    memcpy(state->server, BoltString_get(value), (size_t) (value->size));
-                    BoltLog_info(connection->log, "<SET server=\"%s\">", state->server);
-                    break;
-                }
-                default:
-                    break;
-                }
-            }
-            else if (BoltString_equals(key, "code") && state->data_type==BOLT_V1_FAILURE) {
-                struct BoltValue* value = BoltDictionary_value(metadata, i);
-                switch (BoltValue_type(value)) {
-                case BOLT_STRING: {
-                    ensure_failure_data(state);
-
-                    struct BoltValue* target_value = BoltDictionary_value(state->failure_data, 0);
-                    BoltValue_format_as_String(target_value, BoltString_get(value), value->size);
-
-                    BoltLog_value(connection->log, "<FAILURE code=\"%s\">", target_value,
-                            connection->protocol_version);
-
-                    break;
-                }
-                default:
-                    break;
-                }
-            }
-            else if (BoltString_equals(key, "message") && state->data_type==BOLT_V1_FAILURE) {
-                struct BoltValue* value = BoltDictionary_value(metadata, i);
-                switch (BoltValue_type(value)) {
-                case BOLT_STRING: {
-                    ensure_failure_data(state);
-
-                    struct BoltValue* target_value = BoltDictionary_value(state->failure_data, 1);
-                    BoltValue_format_as_String(target_value, BoltString_get(value), value->size);
-
-                    BoltLog_value(connection->log, "<FAILURE message=\"%s\">", target_value,
-                            connection->protocol_version);
-
-                    break;
-                }
-                default:
-                    break;
-                }
-            }
-            else {
-                struct BoltValue* source_key = BoltDictionary_key(metadata, i);
-                struct BoltValue* source_value = BoltDictionary_value(metadata, i);
-
-                // increase length
-                int32_t index = state->result_metadata->size;
-                BoltValue_format_as_Dictionary(state->result_metadata, index+1);
-
-                struct BoltValue* dest_key = BoltDictionary_key(state->result_metadata, index);
-                struct BoltValue* dest_value = BoltDictionary_value(state->result_metadata, index);
-
-                BoltValue_copy(dest_key, source_key);
-                BoltValue_copy(dest_value, source_value);
-            }
-        }
-        break;
-    }
-    default:
-        break;
-    }
-}
-
-int BoltProtocolV1_set_cypher_template(struct BoltConnection* connection, const char* statement, size_t size)
-{
-    if (size<=INT32_MAX) {
-        struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
-        BoltValue_format_as_String(state->run.statement, statement, (int32_t) (size));
-        return BOLT_SUCCESS;
-    }
-    return BOLT_PROTOCOL_VIOLATION;
-}
-
-int BoltProtocolV1_set_n_cypher_parameters(struct BoltConnection* connection, int32_t size)
-{
-    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
-    BoltValue_format_as_Dictionary(state->run.parameters, size);
-    return BOLT_SUCCESS;
-}
-
-int BoltProtocolV1_set_cypher_parameter_key(struct BoltConnection* connection, int32_t index, const char* key,
-        size_t key_size)
-{
-    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
-    if (BoltDictionary_set_key(state->run.parameters, index, key, key_size)) {
-        return BOLT_PROTOCOL_VIOLATION;
-    }
-    return BOLT_SUCCESS;
-}
-
-struct BoltValue* BoltProtocolV1_cypher_parameter_value(struct BoltConnection* connection, int32_t index)
-{
-    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
-    return BoltDictionary_value(state->run.parameters, index);
-}
-
-int BoltProtocolV1_load_bookmark(struct BoltConnection* connection, const char* bookmark)
-{
-    if (bookmark==NULL) {
-        return BOLT_SUCCESS;
-    }
-    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
-    struct BoltValue* bookmarks;
-    if (state->begin.parameters->size==0) {
-        BoltValue_format_as_Dictionary(state->begin.parameters, 1);
-        if (BoltDictionary_set_key(state->begin.parameters, 0, "bookmarks", 9)) {
-            return BOLT_PROTOCOL_VIOLATION;
-        }
-        bookmarks = BoltDictionary_value(state->begin.parameters, 0);
-        BoltValue_format_as_List(bookmarks, 0);
-    }
-    else {
-        bookmarks = BoltDictionary_value(state->begin.parameters, 0);
-    }
-    int32_t n_bookmarks = bookmarks->size;
-    BoltList_resize(bookmarks, n_bookmarks+1);
-    size_t bookmark_size = strlen(bookmark);
-    if (bookmark_size>INT32_MAX) {
-        return BOLT_PROTOCOL_VIOLATION;
-    }
-    BoltValue_format_as_String(BoltList_value(bookmarks, n_bookmarks), bookmark, (int32_t) (bookmark_size));
-    return BOLT_SUCCESS;
-}
-
-int BoltProtocolV1_load_begin_request(struct BoltConnection* connection)
-{
-    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
-    TRY(BoltProtocolV1_load_message(connection, state->begin.request, 0));
-    BoltValue_format_as_Dictionary(state->begin.parameters, 0);
-    TRY(BoltProtocolV1_load_message(connection, state->discard_request, 0));
-    return BOLT_SUCCESS;
-}
-
-int BoltProtocolV1_load_commit_request(struct BoltConnection* connection)
-{
-    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
-    TRY(BoltProtocolV1_load_message(connection, state->commit.request, 0));
-    TRY(BoltProtocolV1_load_message(connection, state->discard_request, 0));
-    return BOLT_SUCCESS;
-}
-
-int BoltProtocolV1_load_rollback_request(struct BoltConnection* connection)
-{
-    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
-    TRY(BoltProtocolV1_load_message(connection, state->rollback.request, 0));
-    TRY(BoltProtocolV1_load_message(connection, state->discard_request, 0));
-    return BOLT_SUCCESS;
-}
-
-int BoltProtocolV1_load_run_request(struct BoltConnection* connection)
-{
-    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
-    TRY(BoltProtocolV1_load_message(connection, state->run.request, 0));
-    return BOLT_SUCCESS;
-}
-
-int BoltProtocolV1_load_pull_request(struct BoltConnection* connection, int32_t n)
-{
-    if (n>=0) {
-        return BOLT_PROTOCOL_VIOLATION;
-    }
-    else {
-        struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
-        TRY(BoltProtocolV1_load_message(connection, state->pull_request, 0));
-        return BOLT_SUCCESS;
-    }
-}
-
-int BoltProtocolV1_load_reset_request(struct BoltConnection* connection)
-{
-    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
-    TRY(BoltProtocolV1_load_message(connection, state->reset_request, 0));
-    BoltProtocolV1_clear_failure(connection);
-    return BOLT_SUCCESS;
-}
-
-struct BoltValue* BoltProtocolV1_result_fields(struct BoltConnection* connection)
-{
-    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
-    switch (BoltValue_type(state->result_field_names)) {
-    case BOLT_LIST:
-        return state->result_field_names;
-    default:
-        return NULL;
-    }
-}
-
-struct BoltValue* BoltProtocolV1_result_metadata(struct BoltConnection* connection)
-{
-    struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
-    switch (BoltValue_type(state->result_metadata)) {
-    case BOLT_DICTIONARY:
-        return state->result_metadata;
-    default:
-        return NULL;
-    }
+    BoltMem_deallocate(protocol, sizeof(struct BoltProtocol));
 }

--- a/seabolt/src/bolt/protocol/v1.c
+++ b/seabolt/src/bolt/protocol/v1.c
@@ -731,7 +731,7 @@ int BoltProtocolV1_fetch(struct BoltConnection* connection, bolt_request request
     return 1;
 }
 
-int BoltProtocolV1_set_tx_timeout_unsupported(struct BoltConnection* connection, int32_t n)
+int BoltProtocolV1_set_tx_timeout_unsupported(struct BoltConnection* connection, int64_t n)
 {
     return BOLT_PROTOCOL_UNSUPPORTED;
 }

--- a/seabolt/src/bolt/protocol/v1.h
+++ b/seabolt/src/bolt/protocol/v1.h
@@ -34,23 +34,13 @@
 #define BOLT_V1_IGNORED 0x7E
 #define BOLT_V1_FAILURE 0x7F
 
-#define BOLT_MAX_CHUNK_SIZE 65535
-
 struct _run_request {
     struct BoltMessage* request;
     struct BoltValue* statement;
     struct BoltValue* parameters;
 };
 
-struct BoltMessage {
-    int8_t code;
-    struct BoltValue* fields;
-};
-
 struct BoltProtocolV1State {
-    check_struct_signature_func check_readable_struct;
-    check_struct_signature_func check_writable_struct;
-
     // These buffers exclude chunk headers.
     struct BoltBuffer* tx_buffer;
     struct BoltBuffer* rx_buffer;
@@ -66,8 +56,8 @@ struct BoltProtocolV1State {
     /// The last bookmark received from the server
     char* last_bookmark;
 
-    bolt_request_t next_request_id;
-    bolt_request_t response_counter;
+    bolt_request next_request_id;
+    bolt_request response_counter;
     unsigned long long record_counter;
 
     struct _run_request run;
@@ -82,72 +72,16 @@ struct BoltProtocolV1State {
     /// Holder for fetched data and metadata
     int16_t data_type;
     struct BoltValue* data;
-
 };
 
 int BoltProtocolV1_check_readable_struct_signature(int16_t signature);
 
 int BoltProtocolV1_check_writable_struct_signature(int16_t signature);
 
-struct BoltProtocolV1State* BoltProtocolV1_create_state();
-
-void BoltProtocolV1_destroy_state(struct BoltProtocolV1State* state);
-
-struct BoltProtocolV1State* BoltProtocolV1_state(struct BoltConnection* connection);
-
-int BoltProtocolV1_load_message(struct BoltConnection* connection, struct BoltMessage* message, int quiet);
-
-int BoltProtocolV1_compile_INIT(struct BoltMessage* message, const char* user_agent, const struct BoltValue* auth_token,
-        int mask_secure_fields);
-
-int BoltProtocolV1_fetch(struct BoltConnection* connection, bolt_request_t request_id);
-
-/**
- * Top-level unload.
- *
- * For a typical Bolt v1 data stream, this will unload either a summary
- * or the first value of a record.
- *
- * @param connection
- * @return
- */
-int BoltProtocolV1_unload(struct BoltConnection* connection);
-
 const char* BoltProtocolV1_structure_name(int16_t code);
 
-const char* BoltProtocolV1_message_name(int16_t code);
+struct BoltProtocol* BoltProtocolV1_create_protocol();
 
-int BoltProtocolV1_init(struct BoltConnection* connection, const char* user_agent, const struct BoltValue* auth_token);
-
-void BoltProtocolV1_clear_failure(struct BoltConnection* connection);
-
-void BoltProtocolV1_extract_metadata(struct BoltConnection* connection, struct BoltValue* summary);
-
-int BoltProtocolV1_set_cypher_template(struct BoltConnection* connection, const char* statement, size_t size);
-
-int BoltProtocolV1_set_n_cypher_parameters(struct BoltConnection* connection, int32_t size);
-
-int BoltProtocolV1_set_cypher_parameter_key(struct BoltConnection* connection, int32_t index, const char* key,
-        size_t key_size);
-
-struct BoltValue* BoltProtocolV1_cypher_parameter_value(struct BoltConnection* connection, int32_t index);
-
-int BoltProtocolV1_load_bookmark(struct BoltConnection* connection, const char* bookmark);
-
-int BoltProtocolV1_load_begin_request(struct BoltConnection* connection);
-
-int BoltProtocolV1_load_commit_request(struct BoltConnection* connection);
-
-int BoltProtocolV1_load_rollback_request(struct BoltConnection* connection);
-
-int BoltProtocolV1_load_run_request(struct BoltConnection* connection);
-
-int BoltProtocolV1_load_pull_request(struct BoltConnection* connection, int32_t n);
-
-int BoltProtocolV1_load_reset_request(struct BoltConnection* connection);
-
-struct BoltValue* BoltProtocolV1_result_fields(struct BoltConnection* connection);
-
-struct BoltValue* BoltProtocolV1_result_metadata(struct BoltConnection* connection);
+void BoltProtocolV1_destroy_protocol(struct BoltProtocol* state);
 
 #endif // SEABOLT_PROTOCOL_V1

--- a/seabolt/src/bolt/protocol/v1.h
+++ b/seabolt/src/bolt/protocol/v1.h
@@ -36,19 +36,6 @@
 
 #define BOLT_MAX_CHUNK_SIZE 65535
 
-enum BoltProtocolV1Type {
-    BOLT_V1_NULL,
-    BOLT_V1_BOOLEAN,
-    BOLT_V1_INTEGER,
-    BOLT_V1_FLOAT,
-    BOLT_V1_STRING,
-    BOLT_V1_BYTES,
-    BOLT_V1_LIST,
-    BOLT_V1_MAP,
-    BOLT_V1_STRUCTURE,
-    BOLT_V1_RESERVED,
-};
-
 struct _run_request {
     struct BoltMessage* request;
     struct BoltValue* statement;

--- a/seabolt/src/bolt/protocol/v1.h
+++ b/seabolt/src/bolt/protocol/v1.h
@@ -29,16 +29,22 @@
 #include "bolt/connections.h"
 #include "protocol.h"
 
+#define BOLT_V1_INIT        0x01
+#define BOLT_V1_ACK_FAILURE 0x0E
+#define BOLT_V1_RESET       0x0F
+#define BOLT_V1_RUN         0x10
+#define BOLT_V1_DISCARD_ALL 0x2F
+#define BOLT_V1_PULL_ALL    0x3F
+
+#define BOLT_V1_NODE    'N'
+#define BOLT_V1_RELATIONSHIP 'R'
+#define BOLT_V1_UNBOUND_RELATIONSHIP 'r'
+#define BOLT_V1_PATH 'P'
+
 #define BOLT_V1_SUCCESS 0x70
 #define BOLT_V1_RECORD  0x71
 #define BOLT_V1_IGNORED 0x7E
 #define BOLT_V1_FAILURE 0x7F
-
-struct _run_request {
-    struct BoltMessage* request;
-    struct BoltValue* statement;
-    struct BoltValue* parameters;
-};
 
 struct BoltProtocolV1State {
     // These buffers exclude chunk headers.
@@ -60,10 +66,10 @@ struct BoltProtocolV1State {
     bolt_request response_counter;
     unsigned long long record_counter;
 
-    struct _run_request run;
-    struct _run_request begin;
-    struct _run_request commit;
-    struct _run_request rollback;
+    struct BoltMessage* run_request;
+    struct BoltMessage* begin_request;
+    struct BoltMessage* commit_request;
+    struct BoltMessage* rollback_request;
 
     struct BoltMessage* discard_request;
     struct BoltMessage* pull_request;
@@ -80,8 +86,10 @@ int BoltProtocolV1_check_writable_struct_signature(int16_t signature);
 
 const char* BoltProtocolV1_structure_name(int16_t code);
 
+struct BoltProtocolV1State* BoltProtocolV1_state(struct BoltConnection* connection);
+
 struct BoltProtocol* BoltProtocolV1_create_protocol();
 
-void BoltProtocolV1_destroy_protocol(struct BoltProtocol* state);
+void BoltProtocolV1_destroy_protocol(struct BoltProtocol* protocol);
 
 #endif // SEABOLT_PROTOCOL_V1

--- a/seabolt/src/bolt/protocol/v2.c
+++ b/seabolt/src/bolt/protocol/v2.c
@@ -73,12 +73,45 @@ int BoltProtocolV2_check_writable_struct_signature(int16_t signature)
     return 0;
 }
 
-struct BoltProtocolV1State* BoltProtocolV2_create_state()
+const char* BoltProtocolV2_structure_name(int16_t code)
 {
-    struct BoltProtocolV1State* v1_state = BoltProtocolV1_create_state();
+    switch (code) {
+    case POINT_2D:
+        return "Point2D";
+    case POINT_3D:
+        return "Point3D";
+    case LOCAL_DATE:
+        return "LocalDate";
+    case LOCAL_TIME:
+        return "LocalTime";
+    case LOCAL_DATE_TIME:
+        return "LocalDateTime";
+    case OFFSET_TIME:
+        return "OffsetTime";
+    case OFFSET_DATE_TIME:
+        return "OffsetDateTime";
+    case ZONED_DATE_TIME:
+        return "ZonedDateTime";
+    case DURATION:
+        return "Duration";
+    default:
+        return BoltProtocolV1_structure_name(code);
+    }
+}
 
-    v1_state->check_writable_struct = &BoltProtocolV2_check_writable_struct_signature;
-    v1_state->check_readable_struct = &BoltProtocolV2_check_readable_struct_signature;
+struct BoltProtocol* BoltProtocolV2_create_protocol()
+{
+    struct BoltProtocol* v1_protocol = BoltProtocolV1_create_protocol();
 
-    return v1_state;
+    // Overrides for new structure types
+    v1_protocol->structure_name = &BoltProtocolV2_structure_name;
+    v1_protocol->check_writable_struct = &BoltProtocolV2_check_writable_struct_signature;
+    v1_protocol->check_readable_struct = &BoltProtocolV2_check_readable_struct_signature;
+
+    return v1_protocol;
+}
+
+void BoltProtocolV2_destroy_protocol(struct BoltProtocol* protocol)
+{
+    BoltProtocolV1_destroy_protocol(protocol);
 }

--- a/seabolt/src/bolt/protocol/v2.c
+++ b/seabolt/src/bolt/protocol/v2.c
@@ -17,17 +17,8 @@
  * limitations under the License.
  */
 
+#include "v2.h"
 #include "v1.h"
-
-#define POINT_2D            'X'
-#define POINT_3D            'Y'
-#define LOCAL_DATE          'D'
-#define LOCAL_TIME          't'
-#define LOCAL_DATE_TIME     'd'
-#define OFFSET_TIME         'T'
-#define OFFSET_DATE_TIME    'F'
-#define ZONED_DATE_TIME     'f'
-#define DURATION            'E'
 
 int BoltProtocolV2_check_readable_struct_signature(int16_t signature)
 {
@@ -36,15 +27,15 @@ int BoltProtocolV2_check_readable_struct_signature(int16_t signature)
     }
 
     switch (signature) {
-    case POINT_2D:
-    case POINT_3D:
-    case LOCAL_DATE:
-    case LOCAL_DATE_TIME:
-    case LOCAL_TIME:
-    case OFFSET_TIME:
-    case OFFSET_DATE_TIME:
-    case ZONED_DATE_TIME:
-    case DURATION:
+    case BOLT_V2_POINT_2D:
+    case BOLT_V2_POINT_3D:
+    case BOLT_V2_LOCAL_DATE:
+    case BOLT_V2_LOCAL_DATE_TIME:
+    case BOLT_V2_LOCAL_TIME:
+    case BOLT_V2_OFFSET_TIME:
+    case BOLT_V2_OFFSET_DATE_TIME:
+    case BOLT_V2_ZONED_DATE_TIME:
+    case BOLT_V2_DURATION:
         return 1;
     }
 
@@ -58,15 +49,15 @@ int BoltProtocolV2_check_writable_struct_signature(int16_t signature)
     }
 
     switch (signature) {
-    case POINT_2D:
-    case POINT_3D:
-    case LOCAL_DATE:
-    case LOCAL_DATE_TIME:
-    case LOCAL_TIME:
-    case OFFSET_TIME:
-    case OFFSET_DATE_TIME:
-    case ZONED_DATE_TIME:
-    case DURATION:
+    case BOLT_V2_POINT_2D:
+    case BOLT_V2_POINT_3D:
+    case BOLT_V2_LOCAL_DATE:
+    case BOLT_V2_LOCAL_DATE_TIME:
+    case BOLT_V2_LOCAL_TIME:
+    case BOLT_V2_OFFSET_TIME:
+    case BOLT_V2_OFFSET_DATE_TIME:
+    case BOLT_V2_ZONED_DATE_TIME:
+    case BOLT_V2_DURATION:
         return 1;
     }
 
@@ -76,23 +67,23 @@ int BoltProtocolV2_check_writable_struct_signature(int16_t signature)
 const char* BoltProtocolV2_structure_name(int16_t code)
 {
     switch (code) {
-    case POINT_2D:
+    case BOLT_V2_POINT_2D:
         return "Point2D";
-    case POINT_3D:
+    case BOLT_V2_POINT_3D:
         return "Point3D";
-    case LOCAL_DATE:
+    case BOLT_V2_LOCAL_DATE:
         return "LocalDate";
-    case LOCAL_TIME:
+    case BOLT_V2_LOCAL_TIME:
         return "LocalTime";
-    case LOCAL_DATE_TIME:
+    case BOLT_V2_LOCAL_DATE_TIME:
         return "LocalDateTime";
-    case OFFSET_TIME:
+    case BOLT_V2_OFFSET_TIME:
         return "OffsetTime";
-    case OFFSET_DATE_TIME:
+    case BOLT_V2_OFFSET_DATE_TIME:
         return "OffsetDateTime";
-    case ZONED_DATE_TIME:
+    case BOLT_V2_ZONED_DATE_TIME:
         return "ZonedDateTime";
-    case DURATION:
+    case BOLT_V2_DURATION:
         return "Duration";
     default:
         return BoltProtocolV1_structure_name(code);

--- a/seabolt/src/bolt/protocol/v2.h
+++ b/seabolt/src/bolt/protocol/v2.h
@@ -20,6 +20,8 @@
 #ifndef SEABOLT_ALL_V2_H
 #define SEABOLT_ALL_V2_H
 
-struct BoltProtocolV1State* BoltProtocolV2_create_state();
+struct BoltProtocol* BoltProtocolV2_create_protocol();
+
+void BoltProtocolV2_destroy_protocol(struct BoltProtocol* state);
 
 #endif //SEABOLT_ALL_V2_H

--- a/seabolt/src/bolt/protocol/v2.h
+++ b/seabolt/src/bolt/protocol/v2.h
@@ -20,8 +20,18 @@
 #ifndef SEABOLT_ALL_V2_H
 #define SEABOLT_ALL_V2_H
 
+#define BOLT_V2_POINT_2D            'X'
+#define BOLT_V2_POINT_3D            'Y'
+#define BOLT_V2_LOCAL_DATE          'D'
+#define BOLT_V2_LOCAL_TIME          't'
+#define BOLT_V2_LOCAL_DATE_TIME     'd'
+#define BOLT_V2_OFFSET_TIME         'T'
+#define BOLT_V2_OFFSET_DATE_TIME    'F'
+#define BOLT_V2_ZONED_DATE_TIME     'f'
+#define BOLT_V2_DURATION            'E'
+
 struct BoltProtocol* BoltProtocolV2_create_protocol();
 
-void BoltProtocolV2_destroy_protocol(struct BoltProtocol* state);
+void BoltProtocolV2_destroy_protocol(struct BoltProtocol* protocol);
 
 #endif //SEABOLT_ALL_V2_H

--- a/seabolt/src/bolt/protocol/v3.c
+++ b/seabolt/src/bolt/protocol/v3.c
@@ -410,6 +410,13 @@ int BoltProtocolV3_hello(struct BoltConnection* connection, const char* user_age
 
 int BoltProtocolV3_goodbye(struct BoltConnection* connection)
 {
+    struct BoltMessage* goodbye = BoltMessage_create(BOLT_V3_GOODBYE, 0);
+    TRY(BoltProtocolV3_load_message(connection, goodbye, 0));
+    BoltMessage_destroy(goodbye);
+    int status = BoltConnection_send(connection);
+    if (status!=BOLT_SUCCESS) {
+        BoltLog_warning(connection->log, "unable to complete GOODBYE call, returned code is %x", status);
+    }
     return BOLT_SUCCESS;
 }
 

--- a/seabolt/src/bolt/protocol/v3.c
+++ b/seabolt/src/bolt/protocol/v3.c
@@ -469,7 +469,7 @@ int _set_tx_bookmark(struct BoltValue* metadata, struct BoltValue* bookmark_list
     return BOLT_SUCCESS;
 }
 
-int _set_tx_timeout(struct BoltValue* metadata, int32_t tx_timeout)
+int _set_tx_timeout(struct BoltValue* metadata, int64_t tx_timeout)
 {
     struct BoltValue* tx_timeout_value = BoltDictionary_value_by_key(metadata, TX_TIMEOUT_KEY, TX_TIMEOUT_KEY_SIZE);
 
@@ -537,7 +537,7 @@ int BoltProtocolV3_set_begin_tx_bookmark(struct BoltConnection* connection, stru
     return _set_tx_bookmark(metadata, bookmark_list, connection->log, connection->protocol->structure_name);
 }
 
-int BoltProtocolV3_set_begin_tx_timeout(struct BoltConnection* connection, int32_t tx_timeout)
+int BoltProtocolV3_set_begin_tx_timeout(struct BoltConnection* connection, int64_t tx_timeout)
 {
     struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
     struct BoltValue* metadata = BoltMessage_param(state->begin_request, 0);
@@ -592,7 +592,7 @@ int BoltProtocolV3_set_run_tx_metadata(struct BoltConnection* connection, struct
     return _set_tx_metadata(metadata, tx_metadata);
 }
 
-int BoltProtocolV3_set_run_tx_timeout(struct BoltConnection* connection, int32_t tx_timeout)
+int BoltProtocolV3_set_run_tx_timeout(struct BoltConnection* connection, int64_t tx_timeout)
 {
     struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
     struct BoltValue* metadata = BoltMessage_param(state->run_request, 2);

--- a/seabolt/src/bolt/protocol/v3.c
+++ b/seabolt/src/bolt/protocol/v3.c
@@ -123,8 +123,8 @@ void _ensure_failure_data(struct BoltProtocolV3State* state)
     if (state->failure_data==NULL) {
         state->failure_data = BoltValue_create();
         BoltValue_format_as_Dictionary(state->failure_data, 2);
-        BoltDictionary_set_key(state->failure_data, 0, "code", strlen("code"));
-        BoltDictionary_set_key(state->failure_data, 1, "message", strlen("message"));
+        BoltDictionary_set_key(state->failure_data, 0, FAILURE_CODE_KEY, FAILURE_CODE_KEY_SIZE);
+        BoltDictionary_set_key(state->failure_data, 1, FAILURE_MESSAGE_KEY, FAILURE_MESSAGE_KEY_SIZE);
     }
 }
 
@@ -521,7 +521,7 @@ int _set_tx_metadata(struct BoltValue* metadata, struct BoltValue* tx_metadata)
     if (tx_metadata_value==NULL) {
         int32_t index = metadata->size;
         BoltValue_format_as_Dictionary(metadata, metadata->size+1);
-        BoltDictionary_set_key(metadata, index, TX_METADATA_KEY, TX_TIMEOUT_KEY_SIZE);
+        BoltDictionary_set_key(metadata, index, TX_METADATA_KEY, TX_METADATA_KEY_SIZE);
         tx_metadata_value = BoltDictionary_value(metadata, index);
     }
 

--- a/seabolt/src/bolt/protocol/v3.c
+++ b/seabolt/src/bolt/protocol/v3.c
@@ -1,0 +1,1040 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <string.h>
+
+#include "bolt/buffering.h"
+#include "bolt/mem.h"
+#include "bolt/logging.h"
+
+#include "protocol.h"
+#include "v3.h"
+
+#define MASK "********"
+#define MASK_SIZE 8
+#define CREDENTIALS_KEY "credentials"
+#define CREDENTIALS_KEY_SIZE 11
+#define USER_AGENT_KEY "user_agent"
+#define USER_AGENT_KEY_SIZE 10
+#define BOOKMARKS_KEY "bookmarks"
+#define BOOKMARKS_KEY_SIZE 9
+#define TX_TIMEOUT_KEY "tx_timeout"
+#define TX_TIMEOUT_KEY_SIZE 10
+#define TX_METADATA_KEY "tx_metadata"
+#define TX_METADATA_KEY_SIZE 11
+#define BOOKMARK_KEY "bookmark"
+#define BOOKMARK_KEY_SIZE 8
+#define FIELDS_KEY "fields"
+#define FIELDS_KEY_SIZE 6
+#define SERVER_KEY "server"
+#define SERVER_KEY_SIZE 6
+#define FAILURE_CODE_KEY "code"
+#define FAILURE_CODE_KEY_SIZE 4
+#define FAILURE_MESSAGE_KEY "message"
+#define FAILURE_MESSAGE_KEY_SIZE 7
+#define CONNECTION_ID_KEY "connection_id"
+#define CONNECTION_ID_KEY_SIZE 13
+
+#define INITIAL_TX_BUFFER_SIZE 8192
+#define INITIAL_RX_BUFFER_SIZE 8192
+#define MAX_BOOKMARK_SIZE 40
+#define MAX_SERVER_SIZE 200
+#define MAX_CONNECTION_ID_SIZE 200
+#define MAX_LOGGED_RECORDS 3
+
+#define char_to_uint16be(array) ((uint8_t)(header[0]) << 8) | (uint8_t)(header[1]);
+
+#define TRY(code) { int status_try = (code); if (status_try != BOLT_SUCCESS) { return status_try; } }
+
+struct BoltProtocolV3State {
+    // These buffers exclude chunk headers.
+    struct BoltBuffer* tx_buffer;
+    struct BoltBuffer* rx_buffer;
+
+    /// The product name and version of the remote server
+    char* server;
+    /// A BoltValue containing field names for the active result
+    struct BoltValue* result_field_names;
+    /// A BoltValue containing metadata fields
+    struct BoltValue* result_metadata;
+    /// A BoltValue containing error code and message
+    struct BoltValue* failure_data;
+    /// The last bookmark received from the server
+    char* last_bookmark;
+    /// A connection identifier assigned by the server
+    char* connection_id;
+
+    bolt_request next_request_id;
+    bolt_request response_counter;
+    unsigned long long record_counter;
+
+    struct BoltMessage* run_request;
+    struct BoltMessage* begin_request;
+    struct BoltMessage* commit_request;
+    struct BoltMessage* rollback_request;
+
+    struct BoltMessage* discard_request;
+    struct BoltMessage* pull_request;
+    struct BoltMessage* reset_request;
+
+    /// Holder for fetched data and metadata
+    int16_t data_type;
+    struct BoltValue* data;
+};
+
+int _clear_begin_tx(struct BoltMessage* request)
+{
+    struct BoltValue* metadata = BoltMessage_param(request, 0);
+    BoltValue_format_as_Dictionary(metadata, 0);
+    return BOLT_SUCCESS;
+}
+
+int _clear_run(struct BoltMessage* request)
+{
+    struct BoltValue* statement = BoltMessage_param(request, 0);
+    struct BoltValue* params = BoltMessage_param(request, 1);
+    struct BoltValue* metadata = BoltMessage_param(request, 2);
+
+    BoltValue_format_as_String(statement, "", 0);
+    BoltValue_format_as_Dictionary(params, 0);
+    BoltValue_format_as_Dictionary(metadata, 0);
+
+    return BOLT_SUCCESS;
+}
+
+void _ensure_failure_data(struct BoltProtocolV3State* state)
+{
+    if (state->failure_data==NULL) {
+        state->failure_data = BoltValue_create();
+        BoltValue_format_as_Dictionary(state->failure_data, 2);
+        BoltDictionary_set_key(state->failure_data, 0, "code", strlen("code"));
+        BoltDictionary_set_key(state->failure_data, 1, "message", strlen("message"));
+    }
+}
+
+void _clear_failure_data(struct BoltProtocolV3State* state)
+{
+    if (state->failure_data!=NULL) {
+        BoltValue_destroy(state->failure_data);
+        state->failure_data = NULL;
+    }
+}
+
+int BoltProtocolV3_check_readable_struct_signature(int16_t signature)
+{
+    switch (signature) {
+    case BOLT_V3_SUCCESS:
+    case BOLT_V3_FAILURE:
+    case BOLT_V3_IGNORED:
+    case BOLT_V3_RECORD:
+    case BOLT_V3_NODE:
+    case BOLT_V3_RELATIONSHIP:
+    case BOLT_V3_UNBOUND_RELATIONSHIP:
+    case BOLT_V3_PATH:
+    case BOLT_V3_POINT_2D:
+    case BOLT_V3_POINT_3D:
+    case BOLT_V3_LOCAL_DATE:
+    case BOLT_V3_LOCAL_DATE_TIME:
+    case BOLT_V3_LOCAL_TIME:
+    case BOLT_V3_OFFSET_TIME:
+    case BOLT_V3_OFFSET_DATE_TIME:
+    case BOLT_V3_ZONED_DATE_TIME:
+    case BOLT_V3_DURATION:
+        return 1;
+    }
+
+    return 0;
+}
+
+int BoltProtocolV3_check_writable_struct_signature(int16_t signature)
+{
+    switch (signature) {
+    case BOLT_V3_RESET:
+    case BOLT_V3_DISCARD_ALL:
+    case BOLT_V3_PULL_ALL:
+    case BOLT_V3_POINT_2D:
+    case BOLT_V3_POINT_3D:
+    case BOLT_V3_LOCAL_DATE:
+    case BOLT_V3_LOCAL_DATE_TIME:
+    case BOLT_V3_LOCAL_TIME:
+    case BOLT_V3_OFFSET_TIME:
+    case BOLT_V3_OFFSET_DATE_TIME:
+    case BOLT_V3_ZONED_DATE_TIME:
+    case BOLT_V3_DURATION:
+    case BOLT_V3_HELLO:
+    case BOLT_V3_RUN:
+    case BOLT_V3_BEGIN:
+    case BOLT_V3_COMMIT:
+    case BOLT_V3_ROLLBACK:
+    case BOLT_V3_GOODBYE:
+        return 1;
+    }
+
+    return 0;
+}
+
+const char* BoltProtocolV3_structure_name(int16_t code)
+{
+    switch (code) {
+    case BOLT_V3_NODE:
+        return "Node";
+    case BOLT_V3_RELATIONSHIP:
+        return "Relationship";
+    case BOLT_V3_UNBOUND_RELATIONSHIP:
+        return "UnboundRelationship";
+    case BOLT_V3_PATH:
+        return "Path";
+    case BOLT_V3_POINT_2D:
+        return "Point2D";
+    case BOLT_V3_POINT_3D:
+        return "Point3D";
+    case BOLT_V3_LOCAL_DATE:
+        return "LocalDate";
+    case BOLT_V3_LOCAL_TIME:
+        return "LocalTime";
+    case BOLT_V3_LOCAL_DATE_TIME:
+        return "LocalDateTime";
+    case BOLT_V3_OFFSET_TIME:
+        return "OffsetTime";
+    case BOLT_V3_OFFSET_DATE_TIME:
+        return "OffsetDateTime";
+    case BOLT_V3_ZONED_DATE_TIME:
+        return "ZonedDateTime";
+    case BOLT_V3_DURATION:
+        return "Duration";
+    default:
+        return "?";
+    }
+}
+
+const char* BoltProtocolV3_message_name(int16_t code)
+{
+    switch (code) {
+    case BOLT_V3_RESET:
+        return "RESET";
+    case BOLT_V3_DISCARD_ALL:
+        return "DISCARD_ALL";
+    case BOLT_V3_PULL_ALL:
+        return "PULL_ALL";
+    case BOLT_V3_SUCCESS:
+        return "SUCCESS";
+    case BOLT_V3_RECORD:
+        return "RECORD";
+    case BOLT_V3_IGNORED:
+        return "IGNORED";
+    case BOLT_V3_FAILURE:
+        return "FAILURE";
+    case BOLT_V3_HELLO:
+        return "HELLO";
+    case BOLT_V3_RUN:
+        return "RUN";
+    case BOLT_V3_BEGIN:
+        return "BEGIN";
+    case BOLT_V3_COMMIT:
+        return "COMMIT";
+    case BOLT_V3_ROLLBACK:
+        return "ROLLBACK";
+    case BOLT_V3_GOODBYE:
+        return "GOODBYE";
+    default:
+        return "?";
+    }
+}
+
+struct BoltProtocolV3State* BoltProtocolV3_state(struct BoltConnection* connection)
+{
+    return (struct BoltProtocolV3State*) (connection->protocol->proto_state);
+}
+
+struct BoltProtocolV3State* BoltProtocolV3_create_state()
+{
+    struct BoltProtocolV3State* state = BoltMem_allocate(sizeof(struct BoltProtocolV3State));
+
+    state->tx_buffer = BoltBuffer_create(INITIAL_TX_BUFFER_SIZE);
+    state->rx_buffer = BoltBuffer_create(INITIAL_RX_BUFFER_SIZE);
+
+    state->server = BoltMem_allocate(MAX_SERVER_SIZE);
+    memset(state->server, 0, MAX_SERVER_SIZE);
+    state->connection_id = BoltMem_allocate(MAX_CONNECTION_ID_SIZE);
+    memset(state->connection_id, 0, MAX_CONNECTION_ID_SIZE);
+    state->result_field_names = BoltValue_create();
+    state->result_metadata = BoltValue_create();
+    BoltValue_format_as_Dictionary(state->result_metadata, 0);
+    state->failure_data = NULL;
+    state->last_bookmark = BoltMem_allocate(MAX_BOOKMARK_SIZE);
+    memset(state->last_bookmark, 0, MAX_BOOKMARK_SIZE);
+
+    state->next_request_id = 0;
+    state->response_counter = 0;
+
+    state->begin_request = BoltMessage_create(BOLT_V3_BEGIN, 1);
+    _clear_begin_tx(state->begin_request);
+
+    state->run_request = BoltMessage_create(BOLT_V3_RUN, 3);
+    _clear_run(state->run_request);
+
+    state->commit_request = BoltMessage_create(BOLT_V3_COMMIT, 0);
+    state->rollback_request = BoltMessage_create(BOLT_V3_ROLLBACK, 0);
+
+    state->discard_request = BoltMessage_create(BOLT_V3_DISCARD_ALL, 0);
+
+    state->pull_request = BoltMessage_create(BOLT_V3_PULL_ALL, 0);
+
+    state->reset_request = BoltMessage_create(BOLT_V3_RESET, 0);
+
+    state->data_type = BOLT_V3_RECORD;
+    state->data = BoltValue_create();
+    return state;
+}
+
+void BoltProtocolV3_destroy_state(struct BoltProtocolV3State* state)
+{
+    if (state==NULL) return;
+
+    BoltBuffer_destroy(state->tx_buffer);
+    BoltBuffer_destroy(state->rx_buffer);
+
+    BoltMessage_destroy(state->run_request);
+    BoltMessage_destroy(state->begin_request);
+    BoltMessage_destroy(state->commit_request);
+    BoltMessage_destroy(state->rollback_request);
+
+    BoltMessage_destroy(state->discard_request);
+    BoltMessage_destroy(state->pull_request);
+
+    BoltMessage_destroy(state->reset_request);
+
+    BoltMem_deallocate(state->connection_id, MAX_CONNECTION_ID_SIZE);
+    BoltMem_deallocate(state->server, MAX_SERVER_SIZE);
+    if (state->failure_data!=NULL) {
+        BoltValue_destroy(state->failure_data);
+    }
+    BoltValue_destroy(state->result_field_names);
+    BoltValue_destroy(state->result_metadata);
+    BoltMem_deallocate(state->last_bookmark, MAX_BOOKMARK_SIZE);
+
+    BoltValue_destroy(state->data);
+
+    BoltMem_deallocate(state, sizeof(struct BoltProtocolV3State));
+}
+
+int BoltProtocolV3_load_message(struct BoltConnection* connection, struct BoltMessage* message, int quiet)
+{
+    struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
+
+    if (!quiet) {
+        BoltLog_message(connection->log, "C", state->next_request_id, message->code, message->fields,
+                connection->protocol->structure_name, connection->protocol->message_name);
+    }
+
+    int prev_cursor = state->tx_buffer->cursor;
+    int prev_extent = state->tx_buffer->extent;
+    int status = write_message(message, connection->protocol->check_writable_struct, state->tx_buffer, connection->log);
+    if (status==BOLT_SUCCESS) {
+        push_to_transmission(state->tx_buffer, connection->tx_buffer);
+        state->next_request_id += 1;
+    }
+    else {
+        // Reset buffer to its previous state
+        state->tx_buffer->cursor = prev_cursor;
+        state->tx_buffer->extent = prev_extent;
+    }
+    return status;
+}
+
+int
+BoltProtocolV3_compile_HELLO(struct BoltMessage* message, const char* user_agent, const struct BoltValue* auth_token,
+        int mask_secure_fields)
+{
+    struct BoltValue* params = BoltMessage_param(message, 0);
+    BoltValue_format_as_Dictionary(params, auth_token->size+1);
+
+    // copy auth_token
+    for (int32_t i = 0; i<auth_token->size; i++) {
+        struct BoltValue* src_key = BoltDictionary_key(auth_token, i);
+        struct BoltValue* src_value = BoltDictionary_value(auth_token, i);
+
+        struct BoltValue* dest_key = BoltDictionary_key(params, i);
+        struct BoltValue* dest_value = BoltDictionary_value(params, i);
+
+        BoltValue_copy(dest_key, src_key);
+        BoltValue_copy(dest_value, src_value);
+    }
+
+    // add user_agent
+    BoltDictionary_set_key(params, params->size-1, USER_AGENT_KEY, USER_AGENT_KEY_SIZE);
+    struct BoltValue* user_agent_value = BoltDictionary_value(params, params->size-1);
+    BoltValue_format_as_String(user_agent_value, user_agent, (int32_t) (strlen(user_agent)));
+
+    if (mask_secure_fields) {
+        struct BoltValue* secure_value = BoltDictionary_value_by_key(params, CREDENTIALS_KEY, CREDENTIALS_KEY_SIZE);
+        if (secure_value!=NULL) {
+            BoltValue_format_as_String(secure_value, MASK, MASK_SIZE);
+        }
+    }
+
+    return BOLT_SUCCESS;
+}
+
+int BoltProtocolV3_hello(struct BoltConnection* connection, const char* user_agent, const struct BoltValue* auth_token)
+{
+    struct BoltMessage* hello = BoltMessage_create(BOLT_V3_HELLO, 1);
+    struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
+    TRY(BoltProtocolV3_compile_HELLO(hello, user_agent, auth_token, 1));
+    BoltLog_message(connection->log, "C", state->next_request_id, hello->code, hello->fields,
+            connection->protocol->structure_name, connection->protocol->message_name);
+    TRY(BoltProtocolV3_compile_HELLO(hello, user_agent, auth_token, 0));
+    TRY(BoltProtocolV3_load_message(connection, hello, 1));
+    bolt_request hello_request = BoltConnection_last_request(connection);
+    BoltMessage_destroy(hello);
+    TRY(BoltConnection_send(connection));
+    TRY(BoltConnection_fetch_summary(connection, hello_request));
+    return state->data_type;
+}
+
+int BoltProtocolV3_goodbye(struct BoltConnection* connection)
+{
+    return BOLT_SUCCESS;
+}
+
+int BoltProtocolV3_clear_begin_tx(struct BoltConnection* connection)
+{
+    struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
+    return _clear_begin_tx(state->begin_request);
+}
+
+int _set_tx_bookmark(struct BoltValue* metadata, struct BoltValue* bookmark_list, const struct BoltLog* log,
+        name_resolver_func struct_resolver)
+{
+    BoltLog_value(log, "setting transaction_bookmark: %s", bookmark_list, struct_resolver);
+    struct BoltValue* bookmarks_value = BoltDictionary_value_by_key(metadata, BOOKMARKS_KEY, BOOKMARKS_KEY_SIZE);
+
+    if (bookmark_list==NULL) {
+        BoltLog_debug(log, "passed bookmarks list is NULL");
+        if (bookmarks_value!=NULL) {
+            BoltLog_debug(log, "clearing out already set bookmarks");
+            BoltValue_format_as_List(bookmarks_value, 0);
+        }
+
+        return BOLT_SUCCESS;
+    }
+
+    if (BoltValue_type(bookmark_list)!=BOLT_LIST) {
+        BoltLog_debug(log, "passed bookmarks list is not of type BOLT_LIST, it is: %d", BoltValue_type(bookmark_list));
+        return BOLT_PROTOCOL_VIOLATION;
+    }
+
+    for (int32_t i = 0; i<bookmark_list->size; i++) {
+        struct BoltValue* element = BoltList_value(bookmark_list, i);
+
+        if (BoltValue_type(element)!=BOLT_STRING) {
+            BoltLog_debug(log, "passed bookmark at position %d is not of type BOLT_STRING, it is: %d", i,
+                    BoltValue_type(element));
+            return BOLT_PROTOCOL_VIOLATION;
+        }
+
+        if (element->size>INT32_MAX) {
+            BoltLog_debug(log, "passed bookmark at position %d exceeds maximum size %d", i, element->size);
+            return BOLT_PROTOCOL_VIOLATION;
+        }
+    }
+
+    if (bookmarks_value==NULL) {
+        BoltLog_debug(log, "metadata map doesn't contain a key for bookmarks, adding an entry.");
+        int32_t index = metadata->size;
+        BoltValue_format_as_Dictionary(metadata, metadata->size+1);
+        BoltDictionary_set_key(metadata, index, BOOKMARKS_KEY, BOOKMARKS_KEY_SIZE);
+        bookmarks_value = BoltDictionary_value(metadata, index);
+    }
+
+    BoltLog_debug(log, "copying passed in bookmarks list into metadata map");
+    BoltValue_copy(bookmarks_value, bookmark_list);
+
+    return BOLT_SUCCESS;
+}
+
+int _set_tx_timeout(struct BoltValue* metadata, int32_t tx_timeout)
+{
+    struct BoltValue* tx_timeout_value = BoltDictionary_value_by_key(metadata, TX_TIMEOUT_KEY, TX_TIMEOUT_KEY_SIZE);
+
+    if (tx_timeout<0) {
+        if (tx_timeout_value!=NULL) {
+            BoltValue_format_as_Null(tx_timeout_value);
+        }
+
+        return BOLT_SUCCESS;
+    }
+
+    if (tx_timeout_value==NULL) {
+        int32_t index = metadata->size;
+        BoltValue_format_as_Dictionary(metadata, metadata->size+1);
+        BoltDictionary_set_key(metadata, index, TX_TIMEOUT_KEY, TX_TIMEOUT_KEY_SIZE);
+        tx_timeout_value = BoltDictionary_value(metadata, index);
+    }
+
+    BoltValue_format_as_Integer(tx_timeout_value, tx_timeout);
+
+    return BOLT_SUCCESS;
+}
+
+int _set_tx_metadata(struct BoltValue* metadata, struct BoltValue* tx_metadata)
+{
+    struct BoltValue* tx_metadata_value = BoltDictionary_value_by_key(metadata, TX_METADATA_KEY,
+            TX_METADATA_KEY_SIZE);
+
+    if (tx_metadata==NULL) {
+        if (tx_metadata_value!=NULL) {
+            BoltValue_format_as_Dictionary(tx_metadata_value, 0);
+        }
+
+        return BOLT_SUCCESS;
+    }
+
+    if (BoltValue_type(tx_metadata)!=BOLT_DICTIONARY) {
+        return BOLT_PROTOCOL_VIOLATION;
+    }
+
+    for (int32_t i = 0; i<tx_metadata->size; i++) {
+        struct BoltValue* key = BoltDictionary_key(tx_metadata, i);
+
+        if (BoltValue_type(key)!=BOLT_STRING) {
+            return BOLT_PROTOCOL_VIOLATION;
+        }
+    }
+
+    if (tx_metadata_value==NULL) {
+        int32_t index = metadata->size;
+        BoltValue_format_as_Dictionary(metadata, metadata->size+1);
+        BoltDictionary_set_key(metadata, index, TX_METADATA_KEY, TX_TIMEOUT_KEY_SIZE);
+        tx_metadata_value = BoltDictionary_value(metadata, index);
+    }
+
+    BoltValue_copy(tx_metadata_value, tx_metadata);
+
+    return BOLT_SUCCESS;
+}
+
+int BoltProtocolV3_set_begin_tx_bookmark(struct BoltConnection* connection, struct BoltValue* bookmark_list)
+{
+    struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
+    struct BoltValue* metadata = BoltMessage_param(state->begin_request, 0);
+    return _set_tx_bookmark(metadata, bookmark_list, connection->log, connection->protocol->structure_name);
+}
+
+int BoltProtocolV3_set_begin_tx_timeout(struct BoltConnection* connection, int32_t tx_timeout)
+{
+    struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
+    struct BoltValue* metadata = BoltMessage_param(state->begin_request, 0);
+    return _set_tx_timeout(metadata, tx_timeout);
+}
+
+int BoltProtocolV3_set_begin_tx_metadata(struct BoltConnection* connection, struct BoltValue* tx_metadata)
+{
+    struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
+    struct BoltValue* metadata = BoltMessage_param(state->begin_request, 0);
+    return _set_tx_metadata(metadata, tx_metadata);
+}
+
+int BoltProtocolV3_load_begin_tx(struct BoltConnection* connection)
+{
+    struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
+    TRY(BoltProtocolV3_load_message(connection, state->begin_request, 0));
+    return BOLT_SUCCESS;
+}
+
+int BoltProtocolV3_load_commit_tx(struct BoltConnection* connection)
+{
+    struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
+    TRY(BoltProtocolV3_load_message(connection, state->commit_request, 0));
+    return BOLT_SUCCESS;
+}
+
+int BoltProtocolV3_load_rollback_tx(struct BoltConnection* connection)
+{
+    struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
+    TRY(BoltProtocolV3_load_message(connection, state->rollback_request, 0));
+    return BOLT_SUCCESS;
+}
+
+int BoltProtocolV3_clear_run(struct BoltConnection* connection)
+{
+    struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
+    return _clear_run(state->run_request);
+}
+
+int BoltProtocolV3_set_run_bookmark(struct BoltConnection* connection, struct BoltValue* bookmark_list)
+{
+    struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
+    struct BoltValue* metadata = BoltMessage_param(state->run_request, 2);
+    return _set_tx_bookmark(metadata, bookmark_list, connection->log, connection->protocol->structure_name);
+}
+
+int BoltProtocolV3_set_run_tx_metadata(struct BoltConnection* connection, struct BoltValue* tx_metadata)
+{
+    struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
+    struct BoltValue* metadata = BoltMessage_param(state->run_request, 2);
+    return _set_tx_metadata(metadata, tx_metadata);
+}
+
+int BoltProtocolV3_set_run_tx_timeout(struct BoltConnection* connection, int32_t tx_timeout)
+{
+    struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
+    struct BoltValue* metadata = BoltMessage_param(state->run_request, 2);
+    return _set_tx_timeout(metadata, tx_timeout);
+}
+
+int BoltProtocolV3_set_run_cypher(struct BoltConnection* connection, const char* cypher, const size_t cypher_size,
+        int32_t n_parameter)
+{
+    if (cypher_size<=INT32_MAX) {
+        struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
+        struct BoltValue* statement = BoltMessage_param(state->run_request, 0);
+        struct BoltValue* params = BoltMessage_param(state->run_request, 1);
+        BoltValue_format_as_String(statement, cypher, (int32_t) (cypher_size));
+        BoltValue_format_as_Dictionary(params, n_parameter);
+        return BOLT_SUCCESS;
+    }
+
+    return BOLT_PROTOCOL_VIOLATION;
+}
+
+struct BoltValue*
+BoltProtocolV3_set_run_cypher_parameter(struct BoltConnection* connection, int32_t index, const char* name,
+        size_t name_size)
+{
+    struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
+    struct BoltValue* params = BoltMessage_param(state->run_request, 1);
+    BoltDictionary_set_key(params, index, name, name_size);
+    return BoltDictionary_value(params, index);
+}
+
+int BoltProtocolV3_load_run(struct BoltConnection* connection)
+{
+    struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
+    TRY(BoltProtocolV3_load_message(connection, state->run_request, 0));
+    return BOLT_SUCCESS;
+}
+
+int BoltProtocolV3_load_discard(struct BoltConnection* connection, int32_t n)
+{
+    if (n>=0) {
+        return BOLT_PROTOCOL_VIOLATION;
+    }
+    else {
+        struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
+        TRY(BoltProtocolV3_load_message(connection, state->discard_request, 0));
+        return BOLT_SUCCESS;
+    }
+}
+
+int BoltProtocolV3_load_pull(struct BoltConnection* connection, int32_t n)
+{
+    if (n>=0) {
+        return BOLT_PROTOCOL_VIOLATION;
+    }
+    else {
+        struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
+        TRY(BoltProtocolV3_load_message(connection, state->pull_request, 0));
+        return BOLT_SUCCESS;
+    }
+}
+
+int BoltProtocolV3_load_reset(struct BoltConnection* connection)
+{
+    struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
+    TRY(BoltProtocolV3_load_message(connection, state->reset_request, 0));
+    _clear_failure_data(state);
+    return BOLT_SUCCESS;
+}
+
+struct BoltValue* BoltProtocolV3_result_field_names(struct BoltConnection* connection)
+{
+    struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
+    switch (BoltValue_type(state->result_field_names)) {
+    case BOLT_LIST:
+        return state->result_field_names;
+    default:
+        return NULL;
+    }
+}
+
+struct BoltValue* BoltProtocolV3_result_field_values(struct BoltConnection* connection)
+{
+    struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
+    switch (state->data_type) {
+    case BOLT_V3_RECORD:
+        switch (BoltValue_type(state->data)) {
+        case BOLT_LIST: {
+            struct BoltValue* values = BoltList_value(state->data, 0);
+            return values;
+        }
+        default:
+            return NULL;
+        }
+    default:
+        return NULL;
+    }
+}
+
+struct BoltValue* BoltProtocolV3_result_metadata(struct BoltConnection* connection)
+{
+    struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
+    switch (BoltValue_type(state->result_metadata)) {
+    case BOLT_DICTIONARY:
+        return state->result_metadata;
+    default:
+        return NULL;
+    }
+}
+
+struct BoltValue* BoltProtocolV3_failure(struct BoltConnection* connection)
+{
+    struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
+    return state->failure_data;
+}
+
+char* BoltProtocolV3_last_bookmark(struct BoltConnection* connection)
+{
+    struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
+    return state->last_bookmark;
+}
+
+char* BoltProtocolV3_server(struct BoltConnection* connection)
+{
+    struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
+    return state->server;
+}
+
+bolt_request BoltProtocolV3_last_request(struct BoltConnection* connection)
+{
+    struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
+    return state->next_request_id-1;
+}
+
+int BoltProtocolV3_is_success_summary(struct BoltConnection* connection)
+{
+    struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
+    return state->data_type==BOLT_V3_SUCCESS;
+}
+
+int BoltProtocolV3_is_failure_summary(struct BoltConnection* connection)
+{
+    struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
+    return state->data_type==BOLT_V3_FAILURE;
+}
+
+int BoltProtocolV3_is_ignored_summary(struct BoltConnection* connection)
+{
+    struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
+    return state->data_type==BOLT_V3_IGNORED;
+}
+
+int16_t BoltProtocolV3_last_data_type(struct BoltConnection* connection)
+{
+    struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
+    return state->data_type;
+}
+
+int BoltProtocolV3_unload(struct BoltConnection* connection)
+{
+    struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
+    if (BoltBuffer_unloadable(state->rx_buffer)==0) {
+        return 0;
+    }
+
+    uint8_t marker;
+    TRY(BoltBuffer_unload_u8(state->rx_buffer, &marker));
+    if (marker_type(marker)!=PACKSTREAM_STRUCTURE) {
+        return BOLT_PROTOCOL_VIOLATION;
+    }
+
+    uint8_t code;
+    TRY(BoltBuffer_unload_u8(state->rx_buffer, &code));
+    state->data_type = code;
+
+    int32_t size = marker & 0x0F;
+    BoltValue_format_as_List(state->data, size);
+    for (int i = 0; i<size; i++) {
+        TRY(unload(connection->protocol->check_readable_struct, state->rx_buffer, BoltList_value(state->data, i),
+                connection->log));
+    }
+    if (code==BOLT_V3_RECORD) {
+        if (state->record_counter<MAX_LOGGED_RECORDS) {
+            BoltLog_message(connection->log, "S", state->response_counter, code, state->data,
+                    connection->protocol->structure_name, connection->protocol->message_name);
+        }
+        state->record_counter += 1;
+    }
+    else {
+        if (state->record_counter>MAX_LOGGED_RECORDS) {
+            BoltLog_info(connection->log, "S[%d]: Received %llu more records", state->response_counter,
+                    state->record_counter-MAX_LOGGED_RECORDS);
+        }
+        state->record_counter = 0;
+        BoltLog_message(connection->log, "S", state->response_counter, code, state->data,
+                connection->protocol->structure_name, connection->protocol->message_name);
+    }
+    return BOLT_SUCCESS;
+}
+
+void BoltProtocolV3_extract_metadata(struct BoltConnection* connection, struct BoltValue* metadata)
+{
+    struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
+
+    switch (BoltValue_type(metadata)) {
+    case BOLT_DICTIONARY: {
+        for (int32_t i = 0; i<metadata->size; i++) {
+            struct BoltValue* key = BoltDictionary_key(metadata, i);
+
+            if (BoltString_equals(key, BOOKMARK_KEY, BOOKMARK_KEY_SIZE)) {
+                struct BoltValue* value = BoltDictionary_value(metadata, i);
+                switch (BoltValue_type(value)) {
+                case BOLT_STRING: {
+                    memset(state->last_bookmark, 0, MAX_BOOKMARK_SIZE);
+                    memcpy(state->last_bookmark, BoltString_get(value), (size_t) (value->size));
+                    BoltLog_info(connection->log, "<SET last_bookmark=\"%s\">", state->last_bookmark);
+                    break;
+                }
+                default:
+                    break;
+                }
+            }
+            else if (BoltString_equals(key, FIELDS_KEY, FIELDS_KEY_SIZE)) {
+                struct BoltValue* value = BoltDictionary_value(metadata, i);
+                switch (BoltValue_type(value)) {
+                case BOLT_LIST: {
+                    struct BoltValue* target_value = state->result_field_names;
+                    BoltValue_format_as_List(target_value, value->size);
+                    for (int j = 0; j<value->size; j++) {
+                        struct BoltValue* source_value = BoltList_value(value, j);
+                        switch (BoltValue_type(source_value)) {
+                        case BOLT_STRING:
+                            BoltValue_format_as_String(BoltList_value(target_value, j),
+                                    BoltString_get(source_value), source_value->size);
+                            break;
+                        default:
+                            BoltValue_format_as_Null(BoltList_value(target_value, j));
+                        }
+                    }
+                    BoltLog_value(connection->log, "<SET result_field_names=%s>", target_value,
+                            connection->protocol->structure_name);
+                    break;
+                }
+                default:
+                    break;
+                }
+            }
+            else if (BoltString_equals(key, SERVER_KEY, SERVER_KEY_SIZE)) {
+                struct BoltValue* value = BoltDictionary_value(metadata, i);
+                switch (BoltValue_type(value)) {
+                case BOLT_STRING: {
+                    memset(state->server, 0, MAX_SERVER_SIZE);
+                    memcpy(state->server, BoltString_get(value), (size_t) (value->size));
+                    BoltLog_info(connection->log, "<SET server=\"%s\">", state->server);
+                    break;
+                }
+                default:
+                    break;
+                }
+            }
+            else if (BoltString_equals(key, CONNECTION_ID_KEY, CONNECTION_ID_KEY_SIZE)) {
+                struct BoltValue* value = BoltDictionary_value(metadata, i);
+                switch (BoltValue_type(value)) {
+                case BOLT_STRING: {
+                    memset(state->connection_id, 0, MAX_CONNECTION_ID_SIZE);
+                    memcpy(state->connection_id, BoltString_get(value), (size_t) (value->size));
+                    BoltLog_info(connection->log, "<SET connection_id=\"%s\">", state->connection_id);
+                    break;
+                }
+                default:
+                    break;
+                }
+            }
+            else if (BoltString_equals(key, FAILURE_CODE_KEY, FAILURE_CODE_KEY_SIZE)
+                    && state->data_type==BOLT_V3_FAILURE) {
+                struct BoltValue* value = BoltDictionary_value(metadata, i);
+                switch (BoltValue_type(value)) {
+                case BOLT_STRING: {
+                    _ensure_failure_data(state);
+
+                    struct BoltValue* target_value = BoltDictionary_value(state->failure_data, 0);
+                    BoltValue_format_as_String(target_value, BoltString_get(value), value->size);
+
+                    BoltLog_value(connection->log, "<FAILURE code=\"%s\">", target_value,
+                            connection->protocol->structure_name);
+
+                    break;
+                }
+                default:
+                    break;
+                }
+            }
+            else if (BoltString_equals(key, FAILURE_MESSAGE_KEY, FAILURE_MESSAGE_KEY_SIZE)
+                    && state->data_type==BOLT_V3_FAILURE) {
+                struct BoltValue* value = BoltDictionary_value(metadata, i);
+                switch (BoltValue_type(value)) {
+                case BOLT_STRING: {
+                    _ensure_failure_data(state);
+
+                    struct BoltValue* target_value = BoltDictionary_value(state->failure_data, 1);
+                    BoltValue_format_as_String(target_value, BoltString_get(value), value->size);
+
+                    BoltLog_value(connection->log, "<FAILURE message=\"%s\">", target_value,
+                            connection->protocol->structure_name);
+
+                    break;
+                }
+                default:
+                    break;
+                }
+            }
+            else {
+                struct BoltValue* source_key = BoltDictionary_key(metadata, i);
+                struct BoltValue* source_value = BoltDictionary_value(metadata, i);
+
+                // increase length
+                int32_t index = state->result_metadata->size;
+                BoltValue_format_as_Dictionary(state->result_metadata, index+1);
+
+                struct BoltValue* dest_key = BoltDictionary_key(state->result_metadata, index);
+                struct BoltValue* dest_value = BoltDictionary_value(state->result_metadata, index);
+
+                BoltValue_copy(dest_key, source_key);
+                BoltValue_copy(dest_value, source_value);
+            }
+        }
+        break;
+    }
+    default:
+        break;
+    }
+}
+
+int BoltProtocolV3_fetch(struct BoltConnection* connection, bolt_request request_id)
+{
+    struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
+    bolt_request response_id;
+    do {
+        char header[2];
+        int status = BoltConnection_receive(connection, &header[0], 2);
+        if (status!=BOLT_SUCCESS) {
+            BoltLog_error(connection->log, "Could not fetch chunk header");
+            return -1;
+        }
+        uint16_t chunk_size = char_to_uint16be(header);
+        BoltBuffer_compact(state->rx_buffer);
+        while (chunk_size!=0) {
+            status = BoltConnection_receive(connection, BoltBuffer_load_pointer(state->rx_buffer, chunk_size),
+                    chunk_size);
+            if (status!=BOLT_SUCCESS) {
+                BoltLog_error(connection->log, "Could not fetch chunk data");
+                return -1;
+            }
+            status = BoltConnection_receive(connection, &header[0], 2);
+            if (status!=BOLT_SUCCESS) {
+                BoltLog_error(connection->log, "Could not fetch chunk header");
+                return -1;
+            }
+            chunk_size = char_to_uint16be(header);
+        }
+        response_id = state->response_counter;
+        TRY(BoltProtocolV3_unload(connection));
+        if (state->data_type!=BOLT_V3_RECORD) {
+            state->response_counter += 1;
+
+            // Clean existing metadata
+            BoltValue_format_as_Dictionary(state->result_metadata, 0);
+
+            if (state->data->size>=1) {
+                BoltProtocolV3_extract_metadata(connection, BoltList_value(state->data, 0));
+            }
+        }
+    }
+    while (response_id!=request_id);
+
+    if (state->data_type!=BOLT_V3_RECORD) {
+        return 0;
+    }
+
+    return 1;
+}
+
+struct BoltProtocol* BoltProtocolV3_create_protocol()
+{
+    struct BoltProtocol* protocol = BoltMem_allocate(sizeof(struct BoltProtocol));
+
+    protocol->proto_state = BoltProtocolV3_create_state();
+
+    protocol->message_name = &BoltProtocolV3_message_name;
+    protocol->structure_name = &BoltProtocolV3_structure_name;
+
+    protocol->check_readable_struct = &BoltProtocolV3_check_readable_struct_signature;
+    protocol->check_writable_struct = &BoltProtocolV3_check_writable_struct_signature;
+
+    protocol->init = &BoltProtocolV3_hello;
+    protocol->goodbye = &BoltProtocolV3_goodbye;
+
+    protocol->clear_run = &BoltProtocolV3_clear_run;
+    protocol->set_run_cypher = &BoltProtocolV3_set_run_cypher;
+    protocol->set_run_cypher_parameter = &BoltProtocolV3_set_run_cypher_parameter;
+    protocol->set_run_bookmark = &BoltProtocolV3_set_run_bookmark;
+    protocol->set_run_tx_timeout = &BoltProtocolV3_set_run_tx_timeout;
+    protocol->set_run_tx_metadata = &BoltProtocolV3_set_run_tx_metadata;
+    protocol->load_run = &BoltProtocolV3_load_run;
+
+    protocol->clear_begin_tx = &BoltProtocolV3_clear_begin_tx;
+    protocol->set_begin_tx_bookmark = &BoltProtocolV3_set_begin_tx_bookmark;
+    protocol->set_begin_tx_timeout = &BoltProtocolV3_set_begin_tx_timeout;
+    protocol->set_begin_tx_metadata = &BoltProtocolV3_set_begin_tx_metadata;
+    protocol->load_begin_tx = &BoltProtocolV3_load_begin_tx;
+
+    protocol->load_commit_tx = &BoltProtocolV3_load_commit_tx;
+    protocol->load_rollback_tx = &BoltProtocolV3_load_rollback_tx;
+    protocol->load_discard = &BoltProtocolV3_load_discard;
+    protocol->load_pull = &BoltProtocolV3_load_pull;
+    protocol->load_reset = &BoltProtocolV3_load_reset;
+
+    protocol->last_request = &BoltProtocolV3_last_request;
+
+    protocol->field_names = &BoltProtocolV3_result_field_names;
+    protocol->field_values = &BoltProtocolV3_result_field_values;
+    protocol->metadata = &BoltProtocolV3_result_metadata;
+    protocol->failure = &BoltProtocolV3_failure;
+
+    protocol->last_data_type = &BoltProtocolV3_last_data_type;
+    protocol->last_bookmark = &BoltProtocolV3_last_bookmark;
+    protocol->server = &BoltProtocolV3_server;
+
+    protocol->is_failure_summary = &BoltProtocolV3_is_failure_summary;
+    protocol->is_success_summary = &BoltProtocolV3_is_success_summary;
+    protocol->is_ignored_summary = &BoltProtocolV3_is_ignored_summary;
+
+    protocol->fetch = &BoltProtocolV3_fetch;
+
+    return protocol;
+}
+
+void BoltProtocolV3_destroy_protocol(struct BoltProtocol* protocol)
+{
+    if (protocol!=NULL) {
+        BoltProtocolV3_destroy_state(protocol->proto_state);
+    }
+
+    BoltMem_deallocate(protocol, sizeof(struct BoltProtocol));
+}

--- a/seabolt/src/bolt/protocol/v3.h
+++ b/seabolt/src/bolt/protocol/v3.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef SEABOLT_ALL_V3_H
+#define SEABOLT_ALL_V3_H
+
+#include "bolt/connections.h"
+
+#define BOLT_V3_HELLO 0x01
+#define BOLT_V3_GOODBYE 0x02
+#define BOLT_V3_RUN 0x10
+#define BOLT_V3_BEGIN 0x11
+#define BOLT_V3_COMMIT 0x12
+#define BOLT_V3_ROLLBACK 0x13
+#define BOLT_V3_DISCARD_ALL 0x2F
+#define BOLT_V3_PULL_ALL    0x3F
+#define BOLT_V3_RESET       0x0F
+
+#define BOLT_V3_SUCCESS 0x70
+#define BOLT_V3_RECORD  0x71
+#define BOLT_V3_IGNORED 0x7E
+#define BOLT_V3_FAILURE 0x7F
+
+#define BOLT_V3_NODE    'N'
+#define BOLT_V3_RELATIONSHIP 'R'
+#define BOLT_V3_UNBOUND_RELATIONSHIP 'r'
+#define BOLT_V3_PATH 'P'
+#define BOLT_V3_POINT_2D            'X'
+#define BOLT_V3_POINT_3D            'Y'
+#define BOLT_V3_LOCAL_DATE          'D'
+#define BOLT_V3_LOCAL_TIME          't'
+#define BOLT_V3_LOCAL_DATE_TIME     'd'
+#define BOLT_V3_OFFSET_TIME         'T'
+#define BOLT_V3_OFFSET_DATE_TIME    'F'
+#define BOLT_V3_ZONED_DATE_TIME     'f'
+#define BOLT_V3_DURATION            'E'
+
+struct BoltProtocol* BoltProtocolV3_create_protocol();
+
+void BoltProtocolV3_destroy_protocol(struct BoltProtocol* protocol);
+
+#endif //SEABOLT_ALL_V3_H

--- a/seabolt/src/bolt/values.c
+++ b/seabolt/src/bolt/values.c
@@ -356,10 +356,10 @@ char* BoltString_get(const struct BoltValue* value)
            (char*) value->data.as_char : value->data.extended.as_char;
 }
 
-int BoltString_equals(struct BoltValue* value, const char* data)
+int BoltString_equals(struct BoltValue* value, const char* data, const size_t data_size)
 {
     if (BoltValue_type(value)==BOLT_STRING) {
-        const int32_t length = (int32_t) strlen(data);
+        const int32_t length = (int32_t) data_size;
         if (value->size!=length) {
             return 0;
         }

--- a/seabolt/src/bolt/values.c
+++ b/seabolt/src/bolt/values.c
@@ -525,7 +525,7 @@ struct BoltValue* BoltStructure_value(const struct BoltValue* value, int32_t ind
     return &value->data.extended.as_value[index];
 }
 
-int BoltValue_write(struct StringBuilder* builder, struct BoltValue* value, int32_t protocol_version)
+int BoltValue_write(struct StringBuilder* builder, struct BoltValue* value, name_resolver_func struct_name_resolver)
 {
     switch (BoltValue_type(value)) {
     case BOLT_NULL: {
@@ -563,7 +563,7 @@ int BoltValue_write(struct StringBuilder* builder, struct BoltValue* value, int3
                 if (comma) StringBuilder_append(builder, ", ");
                 StringBuilder_append_n(builder, key, (size_t) (BoltDictionary_get_key_size(value, i)));
                 StringBuilder_append(builder, ": ");
-                BoltValue_write(builder, BoltDictionary_value(value, i), protocol_version);
+                BoltValue_write(builder, BoltDictionary_value(value, i), struct_name_resolver);
                 comma = 1;
             }
         }
@@ -574,7 +574,7 @@ int BoltValue_write(struct StringBuilder* builder, struct BoltValue* value, int3
         StringBuilder_append(builder, "[");
         for (int i = 0; i<value->size; i++) {
             if (i>0) StringBuilder_append(builder, ", ");
-            BoltValue_write(builder, BoltList_value(value, i), protocol_version);
+            BoltValue_write(builder, BoltList_value(value, i), struct_name_resolver);
         }
         StringBuilder_append(builder, "]");
         return 0;
@@ -589,21 +589,19 @@ int BoltValue_write(struct StringBuilder* builder, struct BoltValue* value, int3
     }
     case BOLT_STRUCTURE: {
         int16_t code = BoltStructure_code(value);
-        switch (protocol_version) {
-        case 1:
-        case 2: {
-            const char* name = BoltProtocolV1_structure_name(code);
-            StringBuilder_append_f(builder, "$%s", name);
-            break;
+
+        if (struct_name_resolver!=NULL) {
+            StringBuilder_append_f(builder, "$%s", struct_name_resolver(code));
         }
-        default:
+        else {
             StringBuilder_append_f(builder, "$#%c%c%c%c", hex3(&code, 0), hex2(&code, 0), hex1(&code, 0),
                     hex0(&code, 0));
         }
+
         StringBuilder_append(builder, "(");
         for (int i = 0; i<value->size; i++) {
             if (i>0) StringBuilder_append(builder, " ");
-            BoltValue_write(builder, BoltStructure_value(value, i), protocol_version);
+            BoltValue_write(builder, BoltStructure_value(value, i), struct_name_resolver);
         }
         StringBuilder_append(builder, ")");
         return 0;


### PR DESCRIPTION
This PR adds support for Bolt V3 and includes several internal refactoring related to protocol specific implementations.

Specific changes are;

1. `INIT` message is replaced with `HELLO` message (no surface change),
2. `GOODBYE` message is introduced which is sent to the server when closing the connection (no surface change),
3. `BEGIN`, `COMMIT` and `ROLLBACK` messages are introduced, replacing previous ones sent as `RUN` messages. Furthermore, `BEGIN` message accepts `tx_timeout` (timeout to apply for this new transaction) and `tx_metadata` (metadata to associate with this new transaction - see [`dbms.listQueries()`](https://neo4j.com/docs/operations-manual/current/monitoring/query-management/procedures/#query-management-list-queries)) besides `bookmarks`.
4. `RUN` message now also accepts `bookmarks`, `tx_timeout` and `tx_metadata` parameters which applies to the auto-commit transaction that it is wrapped in (if it's not part of a transaction).
 
The changes with `BEGIN` and `RUN` are surfaced as newly introduced list of functions;

`BoltConnection_clear_begin`
`BoltConnection_set_begin_bookmarks`
`BoltConnection_set_begin_tx_timeout`
`BoltConnection_set_begin_tx_metadata`
`BoltConnection_clear_run`
`BoltConnection_set_run_bookmarks`
`BoltConnection_set_run_tx_timeout`
`BoltConnection_set_run_tx_metadata`

PR also includes a couple of function name changes apart those listed above.