### PR TITLE
Avoid multiple use of va_list

### DIFF
--- a/seabolt/src/bolt/logging.c
+++ b/seabolt/src/bolt/logging.c
@@ -125,15 +125,14 @@ void BoltLog_message(const struct BoltLog* log, const char* peer, bolt_request r
         struct BoltValue* fields, name_resolver_func struct_name_resolver, name_resolver_func message_name_resolver)
 {
     if (log!=NULL && log->debug_enabled) {
-        const char* message_name = NULL;
+        const char* message_name = "?";
         if (message_name_resolver!=NULL) {
             message_name = message_name_resolver(code);
         }
 
         struct StringBuilder* builder = StringBuilder_create();
         BoltValue_write(builder, fields, struct_name_resolver);
-        BoltLog_debug(log, "%s[%" PRIu64 "] %s %s", peer, request_id, message_name==NULL ? "?" : message_name,
-                StringBuilder_get_string(builder));
+        BoltLog_debug(log, "%s[%" PRIu64 "] %s %s", peer, request_id, message_name, StringBuilder_get_string(builder));
         StringBuilder_destroy(builder);
     }
 }

--- a/seabolt/src/bolt/values.c
+++ b/seabolt/src/bolt/values.c
@@ -558,10 +558,10 @@ int BoltValue_write(struct StringBuilder* builder, struct BoltValue* value, name
         StringBuilder_append(builder, "{");
         int comma = 0;
         for (int i = 0; i<value->size; i++) {
-            const char* key = BoltDictionary_get_key(value, i);
+            struct BoltValue* key = BoltDictionary_key(value, i);
             if (key!=NULL) {
                 if (comma) StringBuilder_append(builder, ", ");
-                StringBuilder_append_n(builder, key, (size_t) (BoltDictionary_get_key_size(value, i)));
+                StringBuilder_append_n(builder, BoltString_get(key), (size_t) key->size);
                 StringBuilder_append(builder, ": ");
                 BoltValue_write(builder, BoltDictionary_value(value, i), struct_name_resolver);
                 comma = 1;


### PR DESCRIPTION
Logging functions start with a predefined size of buffer for actual message construction (with variadic arguments) and when an overflow occurs it reallocates the required amount of buffer and re-attempts the message construction (with `vsnprintf`).

Previously every `vsnprintf` was using the same `va_list` reference passed to the enclosing function, which is not allowed. This PR creates a copy of the `va_list` before passing it to `vsnprintf`. 