### PR TITLE
Add TLS trust settings

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -15,6 +15,7 @@ done
 shift $((OPTIND -1))
 
 BASE=$(dirname $0)
+DATE_FORMAT="%Y-%m-%dT%H:%M:%S"
 PASSWORD="password"
 BOLT_PORT=7699
 HTTPS_PORT=7698
@@ -186,7 +187,7 @@ function run_tests
 
 }
 
-echo "Seabolt test run started at $(date -Ins)"
+echo "Seabolt test run started at $(date +$DATE_FORMAT)"
 check_boltkit
 compile_debug
 for NEO4J_VERSION in $(grep -E "^[0-9]+\.[0-9]+\.[0-9]+$" COMPATIBILITY)
@@ -215,4 +216,4 @@ then
         fi
     done
 fi
-echo "Seabolt test run completed at $(date -Ins)"
+echo "Seabolt test run completed at $(date +$DATE_FORMAT)"

--- a/seabolt-cli/src/main.c
+++ b/seabolt-cli/src/main.c
@@ -144,6 +144,7 @@ struct Application* app_create(int argc, char** argv)
     config.max_pool_size = 10;
     config.log = create_logger();
     config.address_resolver = NULL;
+    config.trust = NULL;
 
     struct BoltValue* auth_token = BoltAuth_basic(BOLT_CONFIG_USER, BOLT_CONFIG_PASSWORD, NULL);
 
@@ -417,9 +418,9 @@ void app_help()
 
 int main(int argc, char* argv[])
 {
-    struct Application* app = app_create(argc, argv);
-
     Bolt_startup();
+
+    struct Application* app = app_create(argc, argv);
 
     switch (app->command) {
     case CMD_NONE:

--- a/seabolt-integration-test/include/integration.hpp
+++ b/seabolt-integration-test/include/integration.hpp
@@ -38,7 +38,7 @@ extern "C" {
 
 #endif
 
-#define SETTING(name, default_value) ((getenv(name) == nullptr) ? (default_value) : getenv(name))
+#define SETTING(name, default_value) ((char*)((getenv(name) == nullptr) ? (default_value) : getenv(name)))
 
 #define BOLT_IPV4_HOST  SETTING("BOLT_IPV4_HOST", "127.0.0.1")
 #define BOLT_IPV6_HOST  SETTING("BOLT_IPV6_HOST", "::1")

--- a/seabolt-integration-test/src/seabolt.cpp
+++ b/seabolt-integration-test/src/seabolt.cpp
@@ -34,9 +34,10 @@ struct BoltAddress* bolt_get_address(const char* host, const char* port)
 
 struct BoltConnection* bolt_open_b(enum BoltTransport transport, const char* host, const char* port)
 {
+    struct BoltTrust trust{nullptr, 0, 1, 1};
     struct BoltAddress* address = bolt_get_address(host, port);
     struct BoltConnection* connection = BoltConnection_create();
-    BoltConnection_open(connection, transport, address, NULL);
+    BoltConnection_open(connection, transport, address, &trust, NULL);
     BoltAddress_destroy(address);
     REQUIRE(connection->status==BOLT_CONNECTED);
     return connection;

--- a/seabolt-integration-test/src/test_direct.cpp
+++ b/seabolt-integration-test/src/test_direct.cpp
@@ -26,8 +26,9 @@ SCENARIO("Test basic secure connection (IPv4)", "[integration][ipv4][secure]")
     GIVEN("a local server address") {
         struct BoltAddress* address = bolt_get_address(BOLT_IPV4_HOST, BOLT_PORT);
         WHEN("a secure connection is opened") {
+            struct BoltTrust trust{nullptr, 0, 1, 1};
             struct BoltConnection* connection = BoltConnection_create();
-            BoltConnection_open(connection, BOLT_SECURE_SOCKET, address, nullptr);
+            BoltConnection_open(connection, BOLT_SECURE_SOCKET, address, &trust, nullptr);
             THEN("the connection should be connected") {
                 REQUIRE(connection->status==BOLT_CONNECTED);
             }
@@ -43,8 +44,9 @@ SCENARIO("Test basic secure connection (IPv6)", "[integration][ipv6][secure]")
     GIVEN("a local server address") {
         struct BoltAddress* address = bolt_get_address(BOLT_IPV6_HOST, BOLT_PORT);
         WHEN("a secure connection is opened") {
+            struct BoltTrust trust{nullptr, 0, 1, 1};
             struct BoltConnection* connection = BoltConnection_create();
-            BoltConnection_open(connection, BOLT_SECURE_SOCKET, address, nullptr);
+            BoltConnection_open(connection, BOLT_SECURE_SOCKET, address, &trust, nullptr);
             THEN("the connection should be connected") {
                 REQUIRE(connection->status==BOLT_CONNECTED);
             }
@@ -60,8 +62,9 @@ SCENARIO("Test basic insecure connection (IPv4)", "[integration][ipv4][insecure]
     GIVEN("a local server address") {
         struct BoltAddress* address = bolt_get_address(BOLT_IPV4_HOST, BOLT_PORT);
         WHEN("an insecure connection is opened") {
+            struct BoltTrust trust{nullptr, 0, 1, 1};
             struct BoltConnection* connection = BoltConnection_create();
-            BoltConnection_open(connection, BOLT_SOCKET, address, nullptr);
+            BoltConnection_open(connection, BOLT_SOCKET, address, &trust, nullptr);
             THEN("the connection should be connected") {
                 REQUIRE(connection->status==BOLT_CONNECTED);
             }
@@ -78,7 +81,7 @@ SCENARIO("Test basic insecure connection (IPv6)", "[integration][ipv6][insecure]
         struct BoltAddress* address = bolt_get_address(BOLT_IPV6_HOST, BOLT_PORT);
         WHEN("an insecure connection is opened") {
             struct BoltConnection* connection = BoltConnection_create();
-            BoltConnection_open(connection, BOLT_SOCKET, address, nullptr);
+            BoltConnection_open(connection, BOLT_SOCKET, address, nullptr, nullptr);
             THEN("the connection should be connected") {
                 REQUIRE(connection->status==BOLT_CONNECTED);
             }
@@ -95,7 +98,7 @@ SCENARIO("Test secure connection to dead port", "[integration][ipv6][secure]")
         struct BoltAddress* address = bolt_get_address(BOLT_IPV6_HOST, "9999");
         WHEN("a secure connection attempt is made") {
             struct BoltConnection* connection = BoltConnection_create();
-            BoltConnection_open(connection, BOLT_SECURE_SOCKET, address, nullptr);
+            BoltConnection_open(connection, BOLT_SECURE_SOCKET, address, nullptr, nullptr);
             THEN("a DEFUNCT connection should be returned") {
                 REQUIRE(connection->status==BOLT_DEFUNCT);
             }
@@ -112,7 +115,7 @@ SCENARIO("Test insecure connection to dead port", "[integration][ipv6][insecure]
         struct BoltAddress* address = bolt_get_address(BOLT_IPV6_HOST, "9999");
         WHEN("an insecure connection attempt is made") {
             struct BoltConnection* connection = BoltConnection_create();
-            BoltConnection_open(connection, BOLT_SOCKET, address, nullptr);
+            BoltConnection_open(connection, BOLT_SOCKET, address, nullptr, nullptr);
             THEN("a DEFUNCT connection should be returned") {
                 REQUIRE(connection->status==BOLT_DEFUNCT);
             }
@@ -128,8 +131,9 @@ SCENARIO("Test connection reuse after graceful shutdown", "[integration][ipv6][s
     GIVEN("a local server address") {
         struct BoltAddress* address = bolt_get_address(BOLT_IPV6_HOST, BOLT_PORT);
         WHEN("a secure connection is opened") {
+            struct BoltTrust trust{nullptr, 0, 1, 1};
             struct BoltConnection* connection = BoltConnection_create();
-            BoltConnection_open(connection, BOLT_SECURE_SOCKET, address, nullptr);
+            BoltConnection_open(connection, BOLT_SECURE_SOCKET, address, &trust, nullptr);
             THEN("the connection should be connected") {
                 REQUIRE(connection->status==BOLT_CONNECTED);
             }
@@ -137,7 +141,7 @@ SCENARIO("Test connection reuse after graceful shutdown", "[integration][ipv6][s
             THEN("the connection should be disconnected") {
                 REQUIRE(connection->status==BOLT_DISCONNECTED);
             }
-            BoltConnection_open(connection, BOLT_SECURE_SOCKET, address, nullptr);
+            BoltConnection_open(connection, BOLT_SECURE_SOCKET, address, &trust, nullptr);
             THEN("the connection should be connected") {
                 REQUIRE(connection->status==BOLT_CONNECTED);
             }
@@ -153,13 +157,14 @@ SCENARIO("Test connection reuse after graceless shutdown", "[integration][ipv6][
     GIVEN("a local server address") {
         struct BoltAddress* address = bolt_get_address(BOLT_IPV6_HOST, BOLT_PORT);
         WHEN("a secure connection is opened") {
+            struct BoltTrust trust{nullptr, 0, 1, 1};
             struct BoltConnection* connection = BoltConnection_create();
-            BoltConnection_open(connection, BOLT_SECURE_SOCKET, address, nullptr);
+            BoltConnection_open(connection, BOLT_SECURE_SOCKET, address, &trust, nullptr);
             THEN("the connection should be connected") {
                 REQUIRE(connection->status==BOLT_CONNECTED);
             }
             connection->status = BOLT_DEFUNCT;
-            BoltConnection_open(connection, BOLT_SECURE_SOCKET, address, nullptr);
+            BoltConnection_open(connection, BOLT_SECURE_SOCKET, address, &trust, nullptr);
             THEN("the connection should be connected") {
                 REQUIRE(connection->status==BOLT_CONNECTED);
             }

--- a/seabolt-integration-test/src/test_pooling.cpp
+++ b/seabolt-integration-test/src/test_pooling.cpp
@@ -25,7 +25,9 @@ SCENARIO("Test using a pooled connection", "[integration][ipv6][secure][pooling]
 {
     GIVEN("a new connection pool") {
         const auto auth_token = BoltAuth_basic(BOLT_USER, BOLT_PASSWORD, NULL);
-        struct BoltConfig config{BOLT_DIRECT, BOLT_SECURE_SOCKET, BOLT_USER_AGENT, nullptr, nullptr, nullptr, 10};
+        struct BoltTrust trust{nullptr, 0, 1, 1};
+        struct BoltConfig config{BOLT_DIRECT, BOLT_SECURE_SOCKET, &trust, BOLT_USER_AGENT, nullptr, nullptr, nullptr,
+                                 10};
         struct BoltConnector* connector = BoltConnector_create(&BOLT_IPV6_ADDRESS, auth_token, &config);
         WHEN("a connection is acquired") {
             struct BoltConnectionResult result = BoltConnector_acquire(connector, BOLT_ACCESS_MODE_READ);
@@ -47,7 +49,9 @@ SCENARIO("Test reusing a pooled connection", "[integration][ipv6][secure][poolin
 {
     GIVEN("a new connection pool with one entry") {
         const auto auth_token = BoltAuth_basic(BOLT_USER, BOLT_PASSWORD, NULL);
-        struct BoltConfig config{BOLT_DIRECT, BOLT_SECURE_SOCKET, BOLT_USER_AGENT, nullptr, nullptr, nullptr, 1};
+        struct BoltTrust trust{nullptr, 0, 1, 1};
+        struct BoltConfig config{BOLT_DIRECT, BOLT_SECURE_SOCKET, &trust, BOLT_USER_AGENT, nullptr, nullptr, nullptr,
+                                 1};
         struct BoltConnector* connector = BoltConnector_create(&BOLT_IPV6_ADDRESS, auth_token, &config);
         WHEN("a connection is acquired, released and acquired again") {
             struct BoltConnectionResult result1 = BoltConnector_acquire(connector, BOLT_ACCESS_MODE_READ);
@@ -74,7 +78,9 @@ SCENARIO("Test reusing a pooled connection that was abandoned", "[integration][i
 {
     GIVEN("a new connection pool with one entry") {
         const auto auth_token = BoltAuth_basic(BOLT_USER, BOLT_PASSWORD, NULL);
-        struct BoltConfig config{BOLT_DIRECT, BOLT_SECURE_SOCKET, BOLT_USER_AGENT, nullptr, nullptr, nullptr, 1};
+        struct BoltTrust trust{nullptr, 0, 1, 1};
+        struct BoltConfig config{BOLT_DIRECT, BOLT_SECURE_SOCKET, &trust, BOLT_USER_AGENT, nullptr, nullptr,
+                                 nullptr, 1};
         struct BoltConnector* connector = BoltConnector_create(&BOLT_IPV6_ADDRESS, auth_token, &config);
         WHEN("a connection is acquired, released and acquired again") {
             struct BoltConnectionResult result1 = BoltConnector_acquire(connector, BOLT_ACCESS_MODE_READ);
@@ -113,7 +119,9 @@ SCENARIO("Test running out of connections", "[integration][ipv6][secure][pooling
 {
     GIVEN("a new connection pool with one entry") {
         const auto auth_token = BoltAuth_basic(BOLT_USER, BOLT_PASSWORD, NULL);
-        struct BoltConfig config{BOLT_DIRECT, BOLT_SECURE_SOCKET, BOLT_USER_AGENT, nullptr, nullptr, nullptr, 1};
+        struct BoltTrust trust{nullptr, 0, 1, 1};
+        struct BoltConfig config{BOLT_DIRECT, BOLT_SECURE_SOCKET, &trust, BOLT_USER_AGENT, nullptr, nullptr, nullptr,
+                                 1};
         struct BoltConnector* connector = BoltConnector_create(&BOLT_IPV6_ADDRESS, auth_token, &config);
         WHEN("two connections are acquired in turn") {
             struct BoltConnectionResult result1 = BoltConnector_acquire(connector, BOLT_ACCESS_MODE_READ);

--- a/seabolt-test/src/mocks.cpp
+++ b/seabolt-test/src/mocks.cpp
@@ -67,7 +67,7 @@ const char* BoltProtocolV1_message_name(int16_t code) {
 }
 
 int BoltConnection_open(struct BoltConnection* connection, enum BoltTransport transport,
-        struct BoltAddress* address, struct BoltLog* log)
+        struct BoltAddress* address, struct BoltTrust *trust, struct BoltLog* log)
 {
     return 0;
 }

--- a/seabolt/include/bolt/config-impl.h
+++ b/seabolt/include/bolt/config-impl.h
@@ -42,10 +42,12 @@
 #include <time.h>
 
 #if USE_POSIXSOCK
+
 #include <unistd.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
 #include <netinet/tcp.h>
+
 #endif // USE_POSIXSOCK
 
 #if USE_WINSOCK
@@ -65,6 +67,10 @@
 #include <openssl/bio.h>
 #include <openssl/err.h>
 #include <openssl/ssl.h>
+#include <openssl/x509v3.h>
+
+extern int SSL_CTX_TRUST_INDEX;
+extern int SSL_CTX_LOG_INDEX;
 
 #endif // USE_OPENSSL
 

--- a/seabolt/include/bolt/connections.h
+++ b/seabolt/include/bolt/connections.h
@@ -94,6 +94,8 @@ struct BoltConnection;
 
 struct BoltProtocol;
 
+struct BoltTrust;
+
 typedef void (* error_action_func)(struct BoltConnection*, void*);
 
 /**
@@ -122,6 +124,7 @@ struct BoltConnection {
 
     const struct BoltLog* log;
 
+    int owns_ssl_context;
     /// The security context (secure connections only)
     struct ssl_ctx_st* ssl_context;
     /// A secure socket wrapper (secure connections only)
@@ -154,6 +157,13 @@ struct BoltConnection {
 
     error_action_func on_error_cb;
     void* on_error_cb_state;
+};
+
+struct BoltTrust {
+    char* certs;
+    int32_t certs_len;
+    int skip_verify;
+    int skip_verify_hostname;
 };
 
 /**
@@ -205,7 +215,7 @@ PUBLIC void BoltConnection_destroy(struct BoltConnection* connection);
  * @return 0 if the connection was opened successfully, -1 otherwise
  */
 PUBLIC int BoltConnection_open(struct BoltConnection* connection, enum BoltTransport transport,
-        struct BoltAddress* address, struct BoltLog* log);
+        struct BoltAddress* address, struct BoltTrust* trust, struct BoltLog* log);
 
 /**
  * Close a connection.

--- a/seabolt/include/bolt/connector.h
+++ b/seabolt/include/bolt/connector.h
@@ -36,8 +36,9 @@ enum BoltAccessMode {
 struct BoltConfig {
     enum BoltConnectorMode mode;
     enum BoltTransport transport;
-    const char* user_agent;
-    const struct BoltValue* routing_context;
+    struct BoltTrust* trust;
+    char* user_agent;
+    struct BoltValue* routing_context;
     struct BoltAddressResolver* address_resolver;
     struct BoltLog* log;
     uint32_t max_pool_size;

--- a/seabolt/include/bolt/tls.h
+++ b/seabolt/include/bolt/tls.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef SEABOLT_ALL_TLS_H
+#define SEABOLT_ALL_TLS_H
+
+#include "bolt/config-impl.h"
+#include "bolt/logging.h"
+
+struct ssl_ctx_st* create_ssl_ctx(struct BoltTrust* trust, const char* hostname, const struct BoltLog* log);
+
+void free_ssl_context(struct ssl_ctx_st* ctx);
+
+#endif //SEABOLT_ALL_TLS_H

--- a/seabolt/include/bolt/tls.h
+++ b/seabolt/include/bolt/tls.h
@@ -22,8 +22,8 @@
 #include "bolt/config-impl.h"
 #include "bolt/logging.h"
 
-struct ssl_ctx_st* create_ssl_ctx(struct BoltTrust* trust, const char* hostname, const struct BoltLog* log);
+PUBLIC struct ssl_ctx_st* create_ssl_ctx(struct BoltTrust* trust, const char* hostname, const struct BoltLog* log);
 
-void free_ssl_context(struct ssl_ctx_st* ctx);
+PUBLIC void free_ssl_context(struct ssl_ctx_st* ctx);
 
 #endif //SEABOLT_ALL_TLS_H

--- a/seabolt/src/bolt/lifecycle.c
+++ b/seabolt/src/bolt/lifecycle.c
@@ -21,11 +21,31 @@
 #include "bolt/logging.h"
 #include "bolt/config-impl.h"
 
+int SSL_CTX_TRUST_INDEX = -1;
+int SSL_CTX_LOG_INDEX = -1;
+
 void Bolt_startup()
 {
 #if USE_WINSOCK
     WSADATA data;
     WSAStartup(MAKEWORD(2, 2), &data);
+#endif
+
+#if USE_OPENSSL
+    // initialize openssl
+#if OPENSSL_VERSION_NUMBER<0x10100000L
+    SSL_library_init();
+#else
+    OPENSSL_init_ssl(0, NULL);
+#endif
+    // load error strings and have cryto initialized
+    SSL_load_error_strings();
+    OpenSSL_add_all_algorithms();
+
+    // register two ex_data indexes that we'll use to store
+    // BoltTrust and BoltLog instances
+    SSL_CTX_TRUST_INDEX = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL);
+    SSL_CTX_LOG_INDEX = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL);
 #endif
 }
 
@@ -35,4 +55,7 @@ void Bolt_shutdown()
     WSACleanup();
 #endif
 
+#if USE_OPENSSL
+    // we don't need any specific shutdown code for openssl
+#endif
 }

--- a/seabolt/src/bolt/pool/direct-pool.h
+++ b/seabolt/src/bolt/pool/direct-pool.h
@@ -24,8 +24,8 @@
 #ifndef SEABOLT_POOLING_H
 #define SEABOLT_POOLING_H
 
-#include "../../../include/bolt/connector.h"
-#include "../../../include/bolt/platform.h"
+#include "bolt/connector.h"
+#include "bolt/platform.h"
 
 /**
  * Connection pool (experimental)
@@ -35,6 +35,7 @@ struct BoltDirectPool {
     struct BoltAddress* address;
     const struct BoltValue* auth_token;
     const struct BoltConfig* config;
+    struct ssl_ctx_st *ssl_context;
     uint32_t size;
     struct BoltConnection* connections;
 };

--- a/seabolt/src/bolt/tls.c
+++ b/seabolt/src/bolt/tls.c
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/tls.h"
+#include "bolt/connections.h"
+#include "bolt/logging.h"
+
+int verify_callback(int preverify_ok, X509_STORE_CTX* ctx)
+{
+    // get related BoltTrust and BoltLog instances
+    SSL* ssl = X509_STORE_CTX_get_ex_data(ctx, SSL_get_ex_data_X509_STORE_CTX_idx());
+    SSL_CTX* context = SSL_get_SSL_CTX(ssl);
+    struct BoltTrust* trust = (struct BoltTrust*) SSL_CTX_get_ex_data(context, SSL_CTX_TRUST_INDEX);
+    struct BoltLog* log = (struct BoltLog*) SSL_CTX_get_ex_data(context, SSL_CTX_LOG_INDEX);
+
+    // check if preverify is successful or not
+    if (!preverify_ok) {
+        // get the error code, bear in mind that we'll have this callback called twice if both X509
+        // and hostname verification failed
+        int error = X509_STORE_CTX_get_error(ctx);
+
+        switch (error) {
+        case X509_V_ERR_HOSTNAME_MISMATCH:
+            if (trust!=NULL && trust->skip_verify_hostname) {
+                BoltLog_warning(log,
+                        "Openssl reported failure of hostname verification due to a mismatch, but resuming handshake since hostname verification is set to be skipped");
+                return 1;
+            }
+            else {
+                BoltLog_debug(log,
+                        "Openssl reported failure of hostname verification due to a mismatch, aborting handshake");
+                return 0;
+            }
+        default:
+            if (trust!=NULL && trust->skip_verify) {
+                BoltLog_warning(log,
+                        "Openssl reported error '%s' with code '%d' when establishing trust, but resuming handshake since trust verification is set to be skipped",
+                        X509_verify_cert_error_string(error), error);
+                return 1;
+            }
+            else {
+                BoltLog_debug(log,
+                        "Openssl reported error '%s' with code '%d' when establishing trust, aborting handshake",
+                        X509_verify_cert_error_string(error), error);
+                return 0;
+            }
+        }
+    }
+    else {
+        BoltLog_debug(log, "Openssl established trust");
+    }
+
+    return 1;
+}
+
+SSL_CTX* create_ssl_ctx(struct BoltTrust* trust, const char* hostname, const struct BoltLog* log)
+{
+    SSL_CTX* context = NULL;
+    X509_STORE* store = NULL;
+    const SSL_METHOD* ctx_init_method = NULL;
+
+#if OPENSSL_VERSION_NUMBER<0x10100000L
+    ctx_init_method = TLSv1_2_client_method();
+#else
+    ctx_init_method = TLS_client_method();
+#endif
+
+    // create a new SSL_CTX with TLS1.2 enabled
+    context = SSL_CTX_new(ctx_init_method);
+    if (context==NULL) {
+        return NULL;
+    }
+
+    // load trusted certificates
+    int status = 1;
+    if (trust!=NULL && trust->certs!=NULL && trust->certs_len!=0) {
+        // create a new x509 certificate store
+        store = X509_STORE_new();
+        if (store!=NULL) {
+            // add default trust certs to the store, which are pointed by
+            // SSL_CERT_DIR and SSL_CERT_FILE, see more on OPENSSL docs
+            status = X509_STORE_set_default_paths(store);
+        }
+
+        if (status) {
+            // if an explicit PEM encoded certs are provided as part of config
+            if (trust->certs!=NULL && trust->certs_len!=0) {
+                // load the buffer into a BIO memory reader
+                BIO* trusted_certs_bio = BIO_new(BIO_s_mem());
+                BIO_write(trusted_certs_bio, trust->certs, trust->certs_len);
+
+                // read all X509_AUX objects encoded (_AUX suffix tells that these
+                // certificates are to be treated as trusted
+                X509* trusted_cert = PEM_read_bio_X509_AUX(trusted_certs_bio, NULL, NULL, NULL);
+                while (trusted_cert!=NULL) {
+                    X509_STORE_add_cert(store, trusted_cert);
+
+                    trusted_cert = PEM_read_bio_X509_AUX(trusted_certs_bio, NULL, NULL, NULL);
+                }
+
+                // free the BIO reader
+                BIO_free(trusted_certs_bio);
+            }
+        }
+
+        // set trusted certificate store on the context
+        status = SSL_CTX_set1_verify_cert_store(context, store);
+    }
+    else {
+        // set trusted certificates from the defaults, which are pointed by
+        // SSL_CERT_DIR and SSL_CERT_FILE, see more on OPENSSL docs
+        status = SSL_CTX_set_default_verify_paths(context);
+    }
+
+    // Store BoltTrust and BoltLog objects into the context to be used in verification callback
+    SSL_CTX_set_ex_data(context, SSL_CTX_TRUST_INDEX, trust);
+    SSL_CTX_set_ex_data(context, SSL_CTX_LOG_INDEX, (void*) log);
+
+    // Enable hostname verification
+    X509_VERIFY_PARAM* param = SSL_CTX_get0_param(context);
+    X509_VERIFY_PARAM_set_hostflags(param, X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
+    X509_VERIFY_PARAM_set1_host(param, hostname, strlen(hostname));
+
+    // Enable verification and set verify callback
+    SSL_CTX_set_verify(context, SSL_VERIFY_PEER | SSL_VERIFY_CLIENT_ONCE, verify_callback);
+
+    // cleanup context if anything went wrong
+    if (!status && context!=NULL) {
+        SSL_CTX_free(context);
+    }
+
+    // cleanup store if anything went wrong
+    if (!status && store!=NULL) {
+        X509_STORE_free(store);
+    }
+
+    return context;
+}
+
+void free_ssl_context(SSL_CTX* ctx)
+{
+    SSL_CTX_free(ctx);
+}


### PR DESCRIPTION
This PR makes it possible to specify TLS trust settings, either specified as part of `BoltConfig` which will then be applied to any `BoltDirectPool` used or as an argument to `BoltConnection_open` which will apply for that specific connection.

The newly introduced `BoltTrust` is defined as;

```c
struct BoltTrust {
    char* certs;
    int32_t certs_len;
    int skip_verify;
    int skip_verify_hostname;
};
```

where `certs` is a buffer of `PEM` encoded certificates to be treated as trusted and `certs_len` being that buffer's length. `skip_verify` is used to turn on/off overall X509 trust verification and `skip_verify_hostname` is used to turn on/off hostname verification.

Any `skip` condition is logged on the configured `BoltLog` instance as a warning.