### PR TITLE
Error descriptions

### DIFF
--- a/seabolt-integration-test/include/integration.hpp
+++ b/seabolt-integration-test/include/integration.hpp
@@ -25,6 +25,7 @@
 #include <cstdlib>
 
 extern "C" {
+#include "bolt/error.h"
 #include "bolt/auth.h"
 #include "bolt/connections.h"
 #include "bolt/logging.h"

--- a/seabolt/include/bolt/config-impl.h
+++ b/seabolt/include/bolt/config-impl.h
@@ -21,6 +21,7 @@
 
 #include "config.h"
 #include "common-impl.h"
+#include "error.h"
 
 #if defined(_WIN32) && _WIN32_WINNT<0x0600
 #undef _WIN32_WINNT

--- a/seabolt/include/bolt/connections.h
+++ b/seabolt/include/bolt/connections.h
@@ -53,44 +53,6 @@ enum BoltConnectionStatus {
     BOLT_DEFUNCT = 4,               // unrecoverable failure
 };
 
-/**
- *
- */
-enum BoltConnectionError {
-    BOLT_SUCCESS = 0,
-    BOLT_UNKNOWN_ERROR = 1,
-    BOLT_UNSUPPORTED = 2,
-    BOLT_INTERRUPTED = 3,
-    BOLT_CONNECTION_RESET = 4,
-    BOLT_NO_VALID_ADDRESS = 5,
-    BOLT_TIMED_OUT = 6,
-    BOLT_PERMISSION_DENIED = 7,
-    BOLT_OUT_OF_FILES = 8,
-    BOLT_OUT_OF_MEMORY = 9,
-    BOLT_OUT_OF_PORTS = 10,
-    BOLT_CONNECTION_REFUSED = 11,
-    BOLT_NETWORK_UNREACHABLE = 12,
-    BOLT_TLS_ERROR = 13,             // general catch-all for OpenSSL errors :/
-    BOLT_END_OF_TRANSMISSION = 15,
-    BOLT_SERVER_FAILURE = 16,
-    BOLT_TRANSPORT_UNSUPPORTED = 0x400,
-    BOLT_PROTOCOL_VIOLATION = 0x500,
-    BOLT_PROTOCOL_UNSUPPORTED_TYPE = 0x501,
-    BOLT_PROTOCOL_NOT_IMPLEMENTED_TYPE = 0x502,
-    BOLT_PROTOCOL_UNEXPECTED_MARKER = 0x503,
-    BOLT_PROTOCOL_UNSUPPORTED = 0x504,
-    BOLT_POOL_FULL = 0x600,
-    BOLT_POOL_ACQUISITION_TIMED_OUT = 0x601,
-    BOLT_ADDRESS_NOT_RESOLVED = 0x700,
-    BOLT_ROUTING_UNABLE_TO_RETRIEVE_ROUTING_TABLE = 0x800,
-    BOLT_ROUTING_NO_SERVERS_TO_SELECT = 0x801,
-    BOLT_ROUTING_UNABLE_TO_CONSTRUCT_POOL_FOR_SERVER = 0x802,
-    BOLT_ROUTING_UNABLE_TO_REFRESH_ROUTING_TABLE = 0x803,
-    BOLT_ROUTING_UNEXPECTED_DISCOVERY_RESPONSE = 0x804,
-    BOLT_CONNECTION_HAS_MORE_INFO = 0xFFE,
-    BOLT_STATUS_SET = 0xFFF,
-};
-
 struct BoltConnection;
 
 struct BoltProtocol;
@@ -165,7 +127,7 @@ struct BoltConnection {
     /// Current status of the connection
     enum BoltConnectionStatus status;
     /// Current connection error code
-    enum BoltConnectionError error;
+    int error;
     /// Additional context info about error
     char* error_ctx;
 

--- a/seabolt/include/bolt/connector.h
+++ b/seabolt/include/bolt/connector.h
@@ -57,7 +57,7 @@ struct BoltConnector {
 struct BoltConnectionResult {
     struct BoltConnection* connection;
     enum BoltConnectionStatus connection_status;
-    enum BoltConnectionError connection_error;
+    int connection_error;
     char* connection_error_ctx;
 };
 

--- a/seabolt/include/bolt/error.h
+++ b/seabolt/include/bolt/error.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef SEABOLT_ALL_ERROR_H
+#define SEABOLT_ALL_ERROR_H
+
+#include "bolt/config.h"
+
+#define BOLT_SUCCESS 0
+#define BOLT_UNKNOWN_ERROR   1
+#define BOLT_UNSUPPORTED   2
+#define BOLT_INTERRUPTED   3
+#define BOLT_CONNECTION_RESET   4
+#define BOLT_NO_VALID_ADDRESS   5
+#define BOLT_TIMED_OUT   6
+#define BOLT_PERMISSION_DENIED   7
+#define BOLT_OUT_OF_FILES   8
+#define BOLT_OUT_OF_MEMORY   9
+#define BOLT_OUT_OF_PORTS   10
+#define BOLT_CONNECTION_REFUSED   11
+#define BOLT_NETWORK_UNREACHABLE   12
+#define BOLT_TLS_ERROR   13
+#define BOLT_END_OF_TRANSMISSION   15
+#define BOLT_SERVER_FAILURE   16
+#define BOLT_TRANSPORT_UNSUPPORTED   0x400
+#define BOLT_PROTOCOL_VIOLATION   0x500
+#define BOLT_PROTOCOL_UNSUPPORTED_TYPE   0x501
+#define BOLT_PROTOCOL_NOT_IMPLEMENTED_TYPE   0x502
+#define BOLT_PROTOCOL_UNEXPECTED_MARKER   0x503
+#define BOLT_PROTOCOL_UNSUPPORTED   0x504
+#define BOLT_POOL_FULL   0x600
+#define BOLT_POOL_ACQUISITION_TIMED_OUT   0x601
+#define BOLT_ADDRESS_NOT_RESOLVED   0x700
+#define BOLT_ROUTING_UNABLE_TO_RETRIEVE_ROUTING_TABLE   0x800
+#define BOLT_ROUTING_NO_SERVERS_TO_SELECT   0x801
+#define BOLT_ROUTING_UNABLE_TO_CONSTRUCT_POOL_FOR_SERVER   0x802
+#define BOLT_ROUTING_UNABLE_TO_REFRESH_ROUTING_TABLE   0x803
+#define BOLT_ROUTING_UNEXPECTED_DISCOVERY_RESPONSE   0x804
+#define BOLT_CONNECTION_HAS_MORE_INFO   0xFFE
+#define BOLT_STATUS_SET   0xFFF
+
+PUBLIC const char* BoltError_get_string(int code);
+
+#endif //SEABOLT_ALL_ERROR_H

--- a/seabolt/src/bolt/address-resolver.c
+++ b/seabolt/src/bolt/address-resolver.c
@@ -18,8 +18,8 @@
  */
 
 #include "bolt/config-impl.h"
-#include "bolt/mem.h"
 #include "bolt/address-resolver.h"
+#include "bolt/mem.h"
 
 struct BoltAddressResolver* BoltAddressResolver_create()
 {

--- a/seabolt/src/bolt/address.c
+++ b/seabolt/src/bolt/address.c
@@ -18,11 +18,11 @@
  */
 
 
+#include "bolt/config-impl.h"
 #include "bolt/address.h"
+#include "bolt/logging.h"
 #include "bolt/mem.h"
 #include "memory.h"
-#include "bolt/config-impl.h"
-#include "bolt/logging.h"
 
 #define DEFAULT_BOLT_PORT "7687"
 #define DEFAULT_BOLT_HOST "localhost"
@@ -74,7 +74,7 @@ struct BoltAddress* BoltAddress_create_from_string(const char* endpoint_str, int
     return result;
 }
 
-int BoltAddress_resolve(struct BoltAddress* address, struct BoltLog *log)
+int BoltAddress_resolve(struct BoltAddress* address, struct BoltLog* log)
 {
     BoltUtil_mutex_lock(&address->lock);
 

--- a/seabolt/src/bolt/connections.c
+++ b/seabolt/src/bolt/connections.c
@@ -17,23 +17,23 @@
  * limitations under the License.
  */
 
-#include "bolt/config-impl.h"
+#include <assert.h>
 
+#include "bolt/config-impl.h"
 #include "bolt/buffering.h"
 #include "bolt/connections.h"
 #include "bolt/logging.h"
 #include "bolt/mem.h"
-
+#include "bolt/platform.h"
+#include "bolt/tls.h"
 #include "protocol/protocol.h"
 #include "protocol/v1.h"
 #include "protocol/v2.h"
 #include "protocol/v3.h"
-#include "bolt/platform.h"
-#include <assert.h>
-#include <bolt/tls.h>
 
 #define INITIAL_TX_BUFFER_SIZE 8192
 #define INITIAL_RX_BUFFER_SIZE 8192
+#define ERROR_CTX_SIZE 1024
 
 #define MAX_IPADDR_LEN 64
 
@@ -55,15 +55,16 @@
 #define CLOSE(socket) close(socket)
 #endif
 
-#define TRY(code) { \
+#define TRY(code, error_ctx_fmt, file, line) { \
     int status = (code); \
     if (status != BOLT_SUCCESS) { \
         if (status == -1) { \
-            _set_status(connection, BOLT_DEFUNCT, _last_error(connection)); \
+            int last_error = _last_error_code(connection); \
+            _set_status_with_ctx(connection, BOLT_DEFUNCT, _transform_error(last_error), error_ctx_fmt, file, line, last_error); \
         } else if (status == BOLT_STATUS_SET) { \
             return -1; \
         } else { \
-            _set_status(connection, BOLT_DEFUNCT, status); \
+            _set_status_with_ctx(connection, BOLT_DEFUNCT, status, error_ctx_fmt, file, line, -1); \
         } \
         return status; \
     } \
@@ -73,7 +74,7 @@
 #define SHUT_RDWR SD_BOTH
 #endif
 
-enum BoltConnectionError _transform_error(int error_code)
+int _transform_error(int error_code)
 {
 #if USE_WINSOCK
     switch (error_code) {
@@ -145,67 +146,93 @@ int _last_error_code(struct BoltConnection* connection)
 #endif
 }
 
-enum BoltConnectionError _last_error(struct BoltConnection* connection)
-{
-    int error_code = _last_error_code(connection);
-    BoltLog_error(connection->log, "socket error code: %d", error_code);
-    return _transform_error(error_code);
-}
-
-enum BoltConnectionError _last_error_ssl(struct BoltConnection* connection, int ret)
+int _last_error_code_ssl(struct BoltConnection* connection, int ssl_ret, int* ssl_error_code, int* last_error)
 {
     // On windows, SSL_get_error resets WSAGetLastError so we're left without an error code after
     // asking error code - so we're saving it here in case.
     int last_error_saved = _last_error_code(connection);
-    int ssl_error_code = SSL_get_error(connection->ssl, ret);
+    *ssl_error_code = SSL_get_error(connection->ssl, ssl_ret);
     BoltLog_error(connection->log, "ssl error code: %d", ssl_error_code);
-    switch (ssl_error_code) {
+    switch (*ssl_error_code) {
     case SSL_ERROR_NONE:
         return BOLT_SUCCESS;
     case SSL_ERROR_SYSCALL:
     case SSL_ERROR_WANT_READ:
     case SSL_ERROR_WANT_WRITE: {
-        int last_error = _last_error_code(connection);
-        if (last_error==0) {
-            last_error = last_error_saved;
+        *last_error = _last_error_code(connection);
+        if (*last_error==0) {
+            *last_error = last_error_saved;
         }
-        BoltLog_error(connection->log, "socket error code: %d", last_error);
-        return _transform_error(last_error);
+        return _transform_error(*last_error);
     }
     default:
         return BOLT_TLS_ERROR;
     }
 }
 
-void _set_status(struct BoltConnection* connection, enum BoltConnectionStatus status, enum BoltConnectionError error)
+void _status_changed(struct BoltConnection* connection)
+{
+    char* status_text = NULL;
+    switch (connection->status) {
+    case BOLT_DISCONNECTED:
+        status_text = "<DISCONNECTED>";
+        break;
+    case BOLT_CONNECTED:
+        status_text = "<CONNECTED>";
+        break;
+    case BOLT_READY:
+        status_text = "<READY>";
+        break;
+    case BOLT_FAILED:
+        status_text = "<FAILED>";
+        break;
+    case BOLT_DEFUNCT:
+        status_text = "<DEFUNCT>";
+        break;
+    }
+
+    if (connection->error_ctx[0]!=0) {
+        BoltLog_info(connection->log, "%s [%s]", status_text, connection->error_ctx);
+    }
+    else {
+        BoltLog_info(connection->log, "%s", status_text);
+    }
+
+    if (connection->status==BOLT_DEFUNCT || connection->status==BOLT_FAILED) {
+        if (connection->on_error_cb!=NULL) {
+            (*connection->on_error_cb)(connection, connection->on_error_cb_state);
+        }
+    }
+}
+
+void _set_status(struct BoltConnection* connection, enum BoltConnectionStatus status, int error)
 {
     enum BoltConnectionStatus old_status = connection->status;
     connection->status = status;
     connection->error = error;
-    if (status!=old_status) {
-        switch (connection->status) {
-        case BOLT_DISCONNECTED:
-            BoltLog_info(connection->log, "<DISCONNECTED>");
-            break;
-        case BOLT_CONNECTED:
-            BoltLog_info(connection->log, "<CONNECTED>");
-            break;
-        case BOLT_READY:
-            BoltLog_info(connection->log, "<READY>");
-            break;
-        case BOLT_FAILED:
-            BoltLog_info(connection->log, "<FAILED>");
-            break;
-        case BOLT_DEFUNCT:
-            BoltLog_info(connection->log, "<DEFUNCT>");
-            break;
-        }
+    connection->error_ctx[0] = '\0';
 
-        if (connection->status==BOLT_DEFUNCT || connection->status==BOLT_FAILED) {
-            if (connection->on_error_cb!=NULL) {
-                (*connection->on_error_cb)(connection, connection->on_error_cb_state);
-            }
-        }
+    if (status!=old_status) {
+        _status_changed(connection);
+    }
+}
+
+void _set_status_with_ctx(struct BoltConnection* connection, enum BoltConnectionStatus status, int error,
+        const char* error_ctx_format, ...)
+{
+    enum BoltConnectionStatus old_status = connection->status;
+    connection->status = status;
+    connection->error = error;
+    connection->error_ctx[0] = '\0';
+    if (error_ctx_format!=NULL) {
+        va_list args;
+        va_start(args, error_ctx_format);
+        vsnprintf(connection->error_ctx, ERROR_CTX_SIZE, error_ctx_format, args);
+        va_end(args);
+    }
+
+    if (status!=old_status) {
+        _status_changed(connection);
     }
 }
 
@@ -214,14 +241,17 @@ int _socket_configure(struct BoltConnection* connection)
     const int YES = 1, NO = 0;
 
     // Enable TCP_NODELAY
-    TRY(SETSOCKETOPT(connection->socket, IPPROTO_TCP, TCP_NODELAY, &YES, sizeof(YES)));
+    TRY(SETSOCKETOPT(connection->socket, IPPROTO_TCP, TCP_NODELAY, &YES, sizeof(YES)),
+            "_socket_configure(%s:%d), set tcp_nodelay error code: %d", __FILE__, __LINE__);
 
     // Set keep-alive accordingly, default: TRUE
     if (connection->sock_opts==NULL || connection->sock_opts->keepalive) {
-        TRY(SETSOCKETOPT(connection->socket, SOL_SOCKET, SO_KEEPALIVE, &YES, sizeof(YES)));
+        TRY(SETSOCKETOPT(connection->socket, SOL_SOCKET, SO_KEEPALIVE, &YES, sizeof(YES)),
+                "_socket_configure(%s:%d), set so_keepalive error code: %d", __FILE__, __LINE__);
     }
     else {
-        TRY(SETSOCKETOPT(connection->socket, SOL_SOCKET, SO_KEEPALIVE, &NO, sizeof(NO)));
+        TRY(SETSOCKETOPT(connection->socket, SOL_SOCKET, SO_KEEPALIVE, &NO, sizeof(NO)),
+                "_socket_configure(%s:%d), set so_keepalive error code: %d", __FILE__, __LINE__);
     }
 
 #if USE_WINSOCK
@@ -253,8 +283,10 @@ int _socket_configure(struct BoltConnection* connection)
     }
 #endif
 
-    TRY(SETSOCKETOPT(connection->socket, SOL_SOCKET, SO_RCVTIMEO, &recv_timeout, recv_timeout_size));
-    TRY(SETSOCKETOPT(connection->socket, SOL_SOCKET, SO_SNDTIMEO, &send_timeout, send_timeout_size));
+    TRY(SETSOCKETOPT(connection->socket, SOL_SOCKET, SO_RCVTIMEO, &recv_timeout, recv_timeout_size),
+            "_socket_configure(%s:%d), set so_rcvtimeo error code: %d", __FILE__, __LINE__);
+    TRY(SETSOCKETOPT(connection->socket, SOL_SOCKET, SO_SNDTIMEO, &send_timeout, send_timeout_size),
+            "_socket_configure(%s:%d), set so_sndtimeo error code: %d", __FILE__, __LINE__);
 
     return BOLT_SUCCESS;
 }
@@ -297,18 +329,20 @@ int _open(struct BoltConnection* connection, enum BoltTransport transport, const
     }
     default:
         BoltLog_error(connection->log, "Unsupported address family %d", address->ss_family);
-        _set_status(connection, BOLT_DEFUNCT, BOLT_UNSUPPORTED);
+        _set_status_with_ctx(connection, BOLT_DEFUNCT, BOLT_UNSUPPORTED, "_open(%s:%d)", __FILE__, __LINE__);
         return BOLT_STATUS_SET;
     }
     connection->socket = (int) SOCKET(address->ss_family, SOCK_STREAM, IPPROTO_TCP);
     if (connection->socket==-1) {
-        _set_status(connection, BOLT_DEFUNCT, _last_error(connection));
+        int last_error_code = _last_error_code(connection);
+        _set_status_with_ctx(connection, BOLT_DEFUNCT, _transform_error(last_error_code),
+                "_open(%s:%d), socket error code: %d", __FILE__, __LINE__, last_error_code);
         return BOLT_STATUS_SET;
     }
 
     if (connection->sock_opts!=NULL && connection->sock_opts->connect_timeout>0) {
         // enable non-blocking mode
-        TRY(_socket_set_mode(connection, 0));
+        TRY(_socket_set_mode(connection, 0), "_open(%s:%d), _socket_set_mode error code: %d", __FILE__, __LINE__);
 
         // initiate connection
         int status = CONNECT(connection->socket, (struct sockaddr*) (address), ADDR_SIZE(address));
@@ -325,7 +359,8 @@ int _open(struct BoltConnection* connection, enum BoltTransport transport, const
             }
 #endif
             default:
-                _set_status(connection, BOLT_DEFUNCT, _transform_error(error_code));
+                _set_status_with_ctx(connection, BOLT_DEFUNCT, _transform_error(error_code),
+                        "_open(%s:%d), connect error code: %d", __FILE__, __LINE__, error_code);
                 return BOLT_STATUS_SET;
             }
         }
@@ -345,36 +380,41 @@ int _open(struct BoltConnection* connection, enum BoltTransport transport, const
             case 0: {
                 //timeout expired
                 BoltLog_info(connection->log, "Connect timed out");
-                _set_status(connection, BOLT_DEFUNCT, BOLT_TIMED_OUT);
+                _set_status_with_ctx(connection, BOLT_DEFUNCT, BOLT_TIMED_OUT, "_open(%s:%d)", __FILE__, __LINE__);
                 return BOLT_STATUS_SET;
             }
             case 1: {
                 int so_error;
                 int so_error_len = sizeof(int);
 
-                TRY(GETSOCKETOPT(connection->socket, SOL_SOCKET, SO_ERROR, &so_error, &so_error_len));
+                TRY(GETSOCKETOPT(connection->socket, SOL_SOCKET, SO_ERROR, &so_error, &so_error_len),
+                        "_open(%s:%d), getsocketopt error code: %d", __FILE__, __LINE__);
                 if (so_error!=0) {
-                    _set_status(connection, BOLT_DEFUNCT, _transform_error(so_error));
+                    _set_status_with_ctx(connection, BOLT_DEFUNCT, _transform_error(so_error),
+                            "_open(%s:%d), socket error code: %d", __FILE__, __LINE__, so_error);
                     return BOLT_STATUS_SET;
                 }
 
                 break;
             }
-            default:
-                //another error occurred
-                _set_status(connection, BOLT_DEFUNCT, _last_error(connection));
+            default: {
+                int last_error = _last_error_code(connection);
+                _set_status_with_ctx(connection, BOLT_DEFUNCT, _transform_error(last_error),
+                        "_open(%s:%d), select error code: %d", __FILE__, __LINE__, last_error);
                 return BOLT_STATUS_SET;
+            }
             }
         }
 
         // revert to blocking mode
-        TRY(_socket_set_mode(connection, 1));
+        TRY(_socket_set_mode(connection, 1), "_open(%s:%d), _socket_set_mode error code: %d", __FILE__, __LINE__);
     }
     else {
-        TRY(CONNECT(connection->socket, (struct sockaddr*) (address), ADDR_SIZE(address)));
+        TRY(CONNECT(connection->socket, (struct sockaddr*) (address), ADDR_SIZE(address)),
+                "_open(%s:%d), connect error code: %d", __FILE__, __LINE__);
     }
 
-    TRY(_socket_configure(connection));
+    TRY(_socket_configure(connection), "_open(%s:%d), _socket_configure error code: %d", __FILE__, __LINE__);
     BoltUtil_get_time(&connection->metrics.time_opened);
     connection->tx_buffer = BoltBuffer_create(INITIAL_TX_BUFFER_SIZE);
     connection->rx_buffer = BoltBuffer_create(INITIAL_RX_BUFFER_SIZE);
@@ -384,7 +424,7 @@ int _open(struct BoltConnection* connection, enum BoltTransport transport, const
 int _secure(struct BoltConnection* connection, struct BoltTrust* trust)
 {
     int status = 1;
-    // TODO: investigate ways to provide a greater resolution of TLS errors
+
     BoltLog_info(connection->log, "Securing socket");
 
     if (connection->ssl_context==NULL) {
@@ -397,19 +437,35 @@ int _secure(struct BoltConnection* connection, struct BoltTrust* trust)
     // Link to underlying socket
     if (status) {
         status = SSL_set_fd(connection->ssl, connection->socket);
+
+        if (!status) {
+            _set_status_with_ctx(connection, BOLT_DEFUNCT, BOLT_TLS_ERROR,
+                    "_secure(%s:%d), SSL_set_fd returned: %d", __FILE__, __LINE__, status);
+
+        }
     }
 
     // Enable SNI
     if (status) {
         status = SSL_set_tlsext_host_name(connection->ssl, connection->address->host);
+
+        if (!status) {
+            _set_status_with_ctx(connection, BOLT_DEFUNCT, BOLT_TLS_ERROR,
+                    "_secure(%s:%d), SSL_set_tlsext_host_name returned: %d", __FILE__, __LINE__, status);
+
+        }
     }
 
-    status = SSL_connect(connection->ssl);
-    if (status==1) {
-        return 0;
+    if (status) {
+        status = SSL_connect(connection->ssl);
+        if (status==1) {
+            return 0;
+        }
+
+        _set_status_with_ctx(connection, BOLT_DEFUNCT, BOLT_TLS_ERROR, "_secure(%s:%d), SSL_connect returned: %d",
+                __FILE__, __LINE__, status);
     }
 
-    _set_status(connection, BOLT_DEFUNCT, BOLT_TLS_ERROR);
     SSL_free(connection->ssl);
     if (connection->owns_ssl_context) {
         SSL_CTX_free(connection->ssl_context);
@@ -501,14 +557,22 @@ int _send(struct BoltConnection* connection, const char* data, int size)
         }
         else {
             switch (connection->transport) {
-            case BOLT_SOCKET:
-                _set_status(connection, BOLT_DEFUNCT, _last_error(connection));
+            case BOLT_SOCKET: {
+                int last_error = _last_error_code(connection);
+                _set_status_with_ctx(connection, BOLT_DEFUNCT, _transform_error(last_error),
+                        "_send(%s:%d), send error code: %d", __FILE__, __LINE__, last_error);
                 BoltLog_error(connection->log, "Socket error %d on transmit", connection->error);
                 break;
-            case BOLT_SECURE_SOCKET:
-                _set_status(connection, BOLT_DEFUNCT, _last_error_ssl(connection, sent));
+            }
+            case BOLT_SECURE_SOCKET: {
+                int last_error = 0, ssl_error = 0;
+                int last_error_transformed = _last_error_code_ssl(connection, sent, &ssl_error, &last_error);
+                _set_status_with_ctx(connection, BOLT_DEFUNCT, last_error_transformed,
+                        "_send(%s:%d), send_s error code: %d, underlying error code: %d", __FILE__, __LINE__, ssl_error,
+                        last_error);
                 BoltLog_error(connection->log, "SSL error %d on transmit", connection->error);
                 break;
+            }
             }
             return BOLT_TRANSPORT_UNSUPPORTED;
         }
@@ -550,19 +614,28 @@ int _receive(struct BoltConnection* connection, char* buffer, int min_size, int 
         }
         else if (single_received==0) {
             BoltLog_info(connection->log, "Detected end of transmission");
-            _set_status(connection, BOLT_DISCONNECTED, BOLT_END_OF_TRANSMISSION);
+            _set_status_with_ctx(connection, BOLT_DISCONNECTED, BOLT_END_OF_TRANSMISSION,
+                    "_receive(%s:%d), receive returned 0", __FILE__, __LINE__);
             return BOLT_STATUS_SET;
         }
         else {
             switch (connection->transport) {
-            case BOLT_SOCKET:
-                _set_status(connection, BOLT_DEFUNCT, _last_error(connection));
+            case BOLT_SOCKET: {
+                int last_error = _last_error_code(connection);
+                _set_status_with_ctx(connection, BOLT_DEFUNCT, _transform_error(last_error),
+                        "_receive(%s:%d), receive error code: %d", __FILE__, __LINE__, last_error);
                 BoltLog_error(connection->log, "Socket error %d on receive", connection->error);
                 break;
-            case BOLT_SECURE_SOCKET:
-                _set_status(connection, BOLT_DEFUNCT, _last_error_ssl(connection, single_received));
+            }
+            case BOLT_SECURE_SOCKET: {
+                int last_error = 0, ssl_error = 0;
+                int last_error_transformed = _last_error_code_ssl(connection, single_received, &ssl_error, &last_error);
+                _set_status_with_ctx(connection, BOLT_DEFUNCT, last_error_transformed,
+                        "_receive(%s:%d), receive_s error code: %d, underlying error code: %d", __FILE__, __LINE__,
+                        ssl_error, last_error);
                 BoltLog_error(connection->log, "SSL error %d on receive", connection->error);
                 break;
+            }
             }
             return BOLT_STATUS_SET;
         }
@@ -586,9 +659,10 @@ int handshake_b(struct BoltConnection* connection, int32_t _1, int32_t _2, int32
     memcpy_be(&handshake[0x08], &_2, 4);
     memcpy_be(&handshake[0x0C], &_3, 4);
     memcpy_be(&handshake[0x10], &_4, 4);
-    TRY(_send(connection, &handshake[0], 20));
+    TRY(_send(connection, &handshake[0], 20), "handshake_b(%s:%d), _send error code: %d", __FILE__, __LINE__);
     int received = 0;
-    TRY(_receive(connection, &handshake[0], 4, 4, &received));
+    TRY(_receive(connection, &handshake[0], 4, 4, &received), "handshake_b(%s:%d), _receive error code: %d", __FILE__,
+            __LINE__);
     memcpy_be(&connection->protocol_version, &handshake[0], 4);
     BoltLog_info(connection->log, "<SET protocol_version=%d>", connection->protocol_version);
     switch (connection->protocol_version) {
@@ -627,6 +701,7 @@ BoltConnection_open(struct BoltConnection* connection, enum BoltTransport transp
     if (connection->status!=BOLT_DISCONNECTED) {
         BoltConnection_close(connection);
     }
+    connection->error_ctx = (char*) BoltMem_allocate(ERROR_CTX_SIZE);
     connection->log = log;
     // Store connection info
     connection->address = BoltAddress_create(address->host, address->port);
@@ -638,14 +713,16 @@ BoltConnection_open(struct BoltConnection* connection, enum BoltTransport transp
             if (connection->transport==BOLT_SECURE_SOCKET) {
                 const int secured = _secure(connection, trust);
                 if (secured==0) {
-                    TRY(handshake_b(connection, 3, 2, 1, 0));
+                    TRY(handshake_b(connection, 3, 2, 1, 0), "BoltConnection_open(%s:%d), handshake_b error code: %d",
+                            __FILE__, __LINE__);
                 }
                 else {
                     return connection->error;
                 }
             }
             else {
-                TRY(handshake_b(connection, 3, 2, 1, 0));
+                TRY(handshake_b(connection, 3, 2, 1, 0), "BoltConnection_open(%s:%d), handshake_b error code: %d",
+                        __FILE__, __LINE__);
             }
 
             char resolved_host[MAX_IPADDR_LEN], resolved_port[6];
@@ -658,7 +735,8 @@ BoltConnection_open(struct BoltConnection* connection, enum BoltTransport transp
         }
     }
     if (connection->status==BOLT_DISCONNECTED) {
-        _set_status(connection, BOLT_DEFUNCT, BOLT_NO_VALID_ADDRESS);
+        _set_status_with_ctx(connection, BOLT_DEFUNCT, BOLT_NO_VALID_ADDRESS, "BoltConnection_open(%s:%d)", __FILE__,
+                __LINE__);
         return -1;
     }
     return connection->status==BOLT_READY ? BOLT_SUCCESS : connection->error;
@@ -668,6 +746,9 @@ void BoltConnection_close(struct BoltConnection* connection)
 {
     if (connection->status!=BOLT_DISCONNECTED) {
         _close(connection);
+    }
+    if (connection->error_ctx!=NULL) {
+        BoltMem_deallocate(connection->error_ctx, ERROR_CTX_SIZE);
     }
     if (connection->rx_buffer!=NULL) {
         BoltBuffer_destroy(connection->rx_buffer);
@@ -690,7 +771,8 @@ void BoltConnection_close(struct BoltConnection* connection)
 int BoltConnection_send(struct BoltConnection* connection)
 {
     int size = BoltBuffer_unloadable(connection->tx_buffer);
-    TRY(_send(connection, BoltBuffer_unload_pointer(connection->tx_buffer, size), size));
+    TRY(_send(connection, BoltBuffer_unload_pointer(connection->tx_buffer, size), size),
+            "BoltConnection_send(%s:%d), _send error code: %d", __FILE__, __LINE__);
     BoltBuffer_compact(connection->tx_buffer);
     return 0;
 }
@@ -710,7 +792,7 @@ int BoltConnection_receive(struct BoltConnection* connection, char* buffer, int 
             max_size = delta>max_size ? delta : max_size;
             int received = 0;
             TRY(_receive(connection, BoltBuffer_load_pointer(connection->rx_buffer, max_size), delta, max_size,
-                    &received));
+                    &received), "BoltConnection_receive(%s:%d), _receive error code: %d", __FILE__, __LINE__);
             // adjust the buffer extent based on the actual amount of data received
             connection->rx_buffer->extent = connection->rx_buffer->extent-max_size+received;
             delta -= received;
@@ -731,16 +813,20 @@ int BoltConnection_fetch(struct BoltConnection* connection, bolt_request request
             // we may need to update status based on an earlier reported FAILURE
             // which our consumer did not care its result
             if (connection->protocol->failure(connection)!=NULL) {
-                _set_status(connection, BOLT_FAILED, BOLT_SERVER_FAILURE);
+                _set_status_with_ctx(connection, BOLT_FAILED, BOLT_SERVER_FAILURE,
+                        "BoltConnection_fetch(%s:%d), failure upon ignored message", __FILE__, __LINE__);
             }
         }
         else if (connection->protocol->is_failure_summary(connection)) {
-            _set_status(connection, BOLT_FAILED, BOLT_SERVER_FAILURE);
+            _set_status_with_ctx(connection, BOLT_FAILED, BOLT_SERVER_FAILURE,
+                    "BoltConnection_fetch(%s:%d), failure message", __FILE__, __LINE__);
         }
         else {
             BoltLog_error(connection->log, "Protocol violation (received summary code %d)",
                     connection->protocol->last_data_type(connection));
-            _set_status(connection, BOLT_DEFUNCT, BOLT_PROTOCOL_VIOLATION);
+            _set_status_with_ctx(connection, BOLT_DEFUNCT, BOLT_PROTOCOL_VIOLATION,
+                    "BoltConnection_fetch(%s:%d), received summary code: %d", __FILE__, __LINE__,
+                    connection->protocol->last_data_type(connection));
             return FETCH_ERROR;
         }
     }
@@ -791,65 +877,79 @@ BoltConnection_init(struct BoltConnection* connection, const char* user_agent, c
             _set_status(connection, BOLT_READY, BOLT_SUCCESS);
             return 0;
         case BOLT_V1_FAILURE:
-            _set_status(connection, BOLT_DEFUNCT, BOLT_PERMISSION_DENIED);
+            _set_status_with_ctx(connection, BOLT_DEFUNCT, BOLT_PERMISSION_DENIED,
+                    "BoltConnection_init(%s:%d), failure message", __FILE__, __LINE__);
             return -1;
         default:
             BoltLog_error(connection->log, "Protocol violation (received summary code %d)", code);
-            _set_status(connection, BOLT_DEFUNCT, BOLT_PROTOCOL_VIOLATION);
+            _set_status_with_ctx(connection, BOLT_DEFUNCT, BOLT_PROTOCOL_VIOLATION,
+                    "BoltConnection_init(%s:%d), received summary code: %d", __FILE__, __LINE__, code);
             return -1;
         }
     }
     default:
-        _set_status(connection, BOLT_DEFUNCT, BOLT_PROTOCOL_UNSUPPORTED);
+        _set_status_with_ctx(connection, BOLT_DEFUNCT, BOLT_PROTOCOL_UNSUPPORTED, "BoltConnection_init(%s:%d)",
+                __FILE__, __LINE__);
         return -1;
     }
 }
 
 int BoltConnection_clear_begin(struct BoltConnection* connection)
 {
-    TRY(connection->protocol->clear_begin_tx(connection));
+    TRY(connection->protocol->clear_begin_tx(connection), "BoltConnection_clear_begin(%s:%d), error code: %d", __FILE__,
+            __LINE__);
     return BOLT_SUCCESS;
 }
 
 int BoltConnection_set_begin_bookmarks(struct BoltConnection* connection, struct BoltValue* bookmark_list)
 {
-    TRY(connection->protocol->set_begin_tx_bookmark(connection, bookmark_list));
+    TRY(connection->protocol->set_begin_tx_bookmark(connection, bookmark_list),
+            "BoltConnection_set_begin_bookmarks(%s:%d), error code: %d", __FILE__, __LINE__);
     return BOLT_SUCCESS;
 }
 
 int BoltConnection_set_begin_tx_timeout(struct BoltConnection* connection, int64_t timeout)
 {
-    TRY(connection->protocol->set_begin_tx_timeout(connection, timeout));
+    TRY(connection->protocol->set_begin_tx_timeout(connection, timeout),
+            "BoltConnection_set_begin_tx_timeout(%s:%d), error code: %d", __FILE__, __LINE__);
     return BOLT_SUCCESS;
 }
 
 int BoltConnection_set_begin_tx_metadata(struct BoltConnection* connection, struct BoltValue* metadata)
 {
-    TRY(connection->protocol->set_begin_tx_metadata(connection, metadata));
+    TRY(connection->protocol->set_begin_tx_metadata(connection, metadata),
+            "BoltConnection_set_begin_tx_metadata(%s:%d), error code: %d", __FILE__, __LINE__);
     return BOLT_SUCCESS;
 }
 
 int BoltConnection_load_begin_request(struct BoltConnection* connection)
 {
-    TRY(connection->protocol->load_begin_tx(connection));
+    TRY(connection->protocol->load_begin_tx(connection), "BoltConnection_load_begin_request(%s:%d), error code: %d",
+            __FILE__,
+            __LINE__);
     return BOLT_SUCCESS;
 }
 
 int BoltConnection_load_commit_request(struct BoltConnection* connection)
 {
-    TRY(connection->protocol->load_commit_tx(connection));
+    TRY(connection->protocol->load_commit_tx(connection), "BoltConnection_load_commit_request(%s:%d), error code: %d",
+            __FILE__,
+            __LINE__);
     return BOLT_SUCCESS;
 }
 
 int BoltConnection_load_rollback_request(struct BoltConnection* connection)
 {
-    TRY(connection->protocol->load_rollback_tx(connection));
+    TRY(connection->protocol->load_rollback_tx(connection),
+            "BoltConnection_load_rollback_request(%s:%d), error code: %d",
+            __FILE__, __LINE__);
     return BOLT_SUCCESS;
 }
 
 int BoltConnection_clear_run(struct BoltConnection* connection)
 {
-    TRY(connection->protocol->clear_run(connection));
+    TRY(connection->protocol->clear_run(connection), "BoltConnection_clear_run(%s:%d), error code: %d", __FILE__,
+            __LINE__);
     return BOLT_SUCCESS;
 }
 
@@ -857,7 +957,8 @@ int
 BoltConnection_set_run_cypher(struct BoltConnection* connection, const char* cypher, const size_t cypher_size,
         int32_t n_parameter)
 {
-    TRY(connection->protocol->set_run_cypher(connection, cypher, cypher_size, n_parameter));
+    TRY(connection->protocol->set_run_cypher(connection, cypher, cypher_size, n_parameter),
+            "BoltConnection_set_run_cypher(%s:%d), error code: %d", __FILE__, __LINE__);
     return BOLT_SUCCESS;
 }
 
@@ -870,43 +971,50 @@ BoltConnection_set_run_cypher_parameter(struct BoltConnection* connection, int32
 
 int BoltConnection_set_run_bookmarks(struct BoltConnection* connection, struct BoltValue* bookmark_list)
 {
-    TRY(connection->protocol->set_run_bookmark(connection, bookmark_list));
+    TRY(connection->protocol->set_run_bookmark(connection, bookmark_list),
+            "BoltConnection_set_run_bookmarks(%s:%d), error code: %d", __FILE__, __LINE__);
     return BOLT_SUCCESS;
 }
 
 int BoltConnection_set_run_tx_timeout(struct BoltConnection* connection, int64_t timeout)
 {
-    TRY(connection->protocol->set_run_tx_timeout(connection, timeout));
+    TRY(connection->protocol->set_run_tx_timeout(connection, timeout),
+            "BoltConnection_set_run_tx_timeout(%s:%d), error code: %d", __FILE__, __LINE__);
     return BOLT_SUCCESS;
 }
 
 int BoltConnection_set_run_tx_metadata(struct BoltConnection* connection, struct BoltValue* metadata)
 {
-    TRY(connection->protocol->set_run_tx_metadata(connection, metadata));
+    TRY(connection->protocol->set_run_tx_metadata(connection, metadata),
+            "BoltConnection_set_run_tx_metadata(%s:%d), error code: %d", __FILE__, __LINE__);
     return BOLT_SUCCESS;
 }
 
 int BoltConnection_load_run_request(struct BoltConnection* connection)
 {
-    TRY(connection->protocol->load_run(connection));
+    TRY(connection->protocol->load_run(connection), "BoltConnection_load_run_request(%s:%d), error code: %d", __FILE__,
+            __LINE__);
     return BOLT_SUCCESS;
 }
 
 int BoltConnection_load_discard_request(struct BoltConnection* connection, int32_t n)
 {
-    TRY(connection->protocol->load_discard(connection, n));
+    TRY(connection->protocol->load_discard(connection, n), "BoltConnection_load_discard_request(%s:%d), error code: %d",
+            __FILE__, __LINE__);
     return BOLT_SUCCESS;
 }
 
 int BoltConnection_load_pull_request(struct BoltConnection* connection, int32_t n)
 {
-    TRY(connection->protocol->load_pull(connection, n));
+    TRY(connection->protocol->load_pull(connection, n), "BoltConnection_load_pull_request(%s:%d), error code: %d",
+            __FILE__, __LINE__);
     return BOLT_SUCCESS;
 }
 
 int BoltConnection_load_reset_request(struct BoltConnection* connection)
 {
-    TRY(connection->protocol->load_reset(connection));
+    TRY(connection->protocol->load_reset(connection), "BoltConnection_load_reset_request(%s:%d), error code: %d",
+            __FILE__, __LINE__);
     return BOLT_SUCCESS;
 }
 

--- a/seabolt/src/bolt/connector.c
+++ b/seabolt/src/bolt/connector.c
@@ -19,11 +19,11 @@
 
 #include "bolt/config-impl.h"
 #include "bolt/connector.h"
-#include "bolt/mem.h"
 #include "bolt/logging.h"
+#include "bolt/mem.h"
+#include "bolt/tls.h"
 #include "pool/direct-pool.h"
 #include "pool/routing-pool.h"
-#include "bolt/tls.h"
 
 #define SIZE_OF_CONNECTOR sizeof(struct BoltConnector)
 #define SIZE_OF_CONFIG sizeof(struct BoltConfig)

--- a/seabolt/src/bolt/error.c
+++ b/seabolt/src/bolt/error.c
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4jcom]
+ *
+ * This file is part of Neo4j
+ *
+ * Licensed under the Apache License, Version 20 (the "License");
+ * you may not use this file except in compliance with the License
+ * You may obtain a copy of the License at
+ *
+ *     http://wwwapacheorg/licenses/LICENSE-20
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+#include "bolt/config-impl.h"
+
+const char* BoltError_get_string(int code)
+{
+    switch (code) {
+    case BOLT_SUCCESS:
+        return "operation succeeded";
+    case BOLT_UNKNOWN_ERROR:
+        return "an unknown error occurred";
+    case BOLT_UNSUPPORTED:
+        return "an unsupported protocol or address family";
+    case BOLT_INTERRUPTED:
+        return "a blocking operation interrupted";
+    case BOLT_CONNECTION_RESET:
+        return "connection reset";
+    case BOLT_NO_VALID_ADDRESS:
+        return "no valid resolved addresses found to connect";
+    case BOLT_TIMED_OUT:
+        return "an operation timed out";
+    case BOLT_PERMISSION_DENIED:
+        return "permission denied";
+    case BOLT_OUT_OF_FILES:
+        return "too may open files";
+    case BOLT_OUT_OF_MEMORY:
+        return "out of memory";
+    case BOLT_OUT_OF_PORTS:
+        return "too many open ports";
+    case BOLT_CONNECTION_REFUSED:
+        return "connection refused";
+    case BOLT_NETWORK_UNREACHABLE:
+        return "network unreachable";
+    case BOLT_TLS_ERROR:
+        return "an unknown TLS error";
+    case BOLT_END_OF_TRANSMISSION:
+        return "connection closed by remote peer";
+    case BOLT_SERVER_FAILURE:
+        return "neo4j failure";
+    case BOLT_TRANSPORT_UNSUPPORTED:
+        return "unsupported bolt transport";
+    case BOLT_PROTOCOL_VIOLATION:
+        return "unsupported protocol usage";
+    case BOLT_PROTOCOL_UNSUPPORTED_TYPE:
+        return "unsupported bolt type";
+    case BOLT_PROTOCOL_NOT_IMPLEMENTED_TYPE:
+        return "unknown pack stream type";
+    case BOLT_PROTOCOL_UNEXPECTED_MARKER:
+        return "unexpected marker";
+    case BOLT_PROTOCOL_UNSUPPORTED:
+        return "unsupported bolt protocol version";
+    case BOLT_POOL_FULL:
+        return "connection pool full";
+    case BOLT_POOL_ACQUISITION_TIMED_OUT:
+        return "connection acquisition from the connection pool timed out";
+    case BOLT_ADDRESS_NOT_RESOLVED:
+        return "address resolution failed";
+    case BOLT_ROUTING_UNABLE_TO_RETRIEVE_ROUTING_TABLE:
+        return "routing table retrieval failed";
+    case BOLT_ROUTING_NO_SERVERS_TO_SELECT:
+        return "no servers to select for the requested operation";
+    case BOLT_ROUTING_UNABLE_TO_CONSTRUCT_POOL_FOR_SERVER:
+        return "connection pool construction for server failed";
+    case BOLT_ROUTING_UNABLE_TO_REFRESH_ROUTING_TABLE:
+        return "routing table refresh failed";
+    case BOLT_ROUTING_UNEXPECTED_DISCOVERY_RESPONSE:
+        return "invalid discovery response";
+    case BOLT_CONNECTION_HAS_MORE_INFO:
+        return "error set in connection";
+    case BOLT_STATUS_SET:
+        return "error set in connection";
+    default:
+        return "UNKNOWN ERROR CODE";
+    }
+}

--- a/seabolt/src/bolt/lifecycle.c
+++ b/seabolt/src/bolt/lifecycle.c
@@ -17,9 +17,9 @@
  * limitations under the License.
  */
 
+#include "bolt/config-impl.h"
 #include "bolt/lifecycle.h"
 #include "bolt/logging.h"
-#include "bolt/config-impl.h"
 
 int SSL_CTX_TRUST_INDEX = -1;
 int SSL_CTX_LOG_INDEX = -1;

--- a/seabolt/src/bolt/logging.c
+++ b/seabolt/src/bolt/logging.c
@@ -23,7 +23,6 @@
 
 #include "bolt/logging.h"
 #include "bolt/mem.h"
-
 #include "protocol/v1.h"
 
 struct BoltLog* BoltLog_create()

--- a/seabolt/src/bolt/platform.c
+++ b/seabolt/src/bolt/platform.c
@@ -18,8 +18,8 @@
 */
 
 #include "bolt/config-impl.h"
-#include "bolt/platform.h"
 #include "bolt/mem.h"
+#include "bolt/platform.h"
 
 #ifdef __APPLE__
 #include <mach/clock.h>

--- a/seabolt/src/bolt/pool/direct-pool.c
+++ b/seabolt/src/bolt/pool/direct-pool.c
@@ -17,16 +17,14 @@
  * limitations under the License.
  */
 
-#include <bolt/connections.h>
-#include <bolt/tls.h>
 #include "bolt/config-impl.h"
+#include "bolt/connections.h"
 #include "bolt/logging.h"
 #include "bolt/mem.h"
+#include "bolt/tls.h"
 #include "bolt/utils.h"
 #include "direct-pool.h"
 #include "../protocol/protocol.h"
-
-#define SIZE_OF_CONNECTION_POOL sizeof(struct BoltConnectionPool)
 
 void close_pool_entry(struct BoltDirectPool* pool, int index)
 {
@@ -82,7 +80,7 @@ int find_connection(struct BoltDirectPool* pool, struct BoltConnection* connecti
     return -1;
 }
 
-enum BoltConnectionError init(struct BoltDirectPool* pool, int index)
+int init(struct BoltDirectPool* pool, int index)
 {
     struct BoltConnection* connection = &pool->connections[index];
     switch (BoltConnection_init(connection, pool->config->user_agent, pool->auth_token)) {
@@ -118,7 +116,7 @@ int reset(struct BoltDirectPool* pool, int index)
     }
 }
 
-enum BoltConnectionError open_init(struct BoltDirectPool* pool, int index)
+int open_init(struct BoltDirectPool* pool, int index)
 {
     // Host name resolution is carried out every time a connection
     // is opened. Given that connections are pooled and reused,
@@ -139,7 +137,7 @@ enum BoltConnectionError open_init(struct BoltDirectPool* pool, int index)
     }
 }
 
-enum BoltConnectionError reset_or_open_init(struct BoltDirectPool* pool, int index)
+int reset_or_open_init(struct BoltDirectPool* pool, int index)
 {
     switch (reset(pool, index)) {
     case 0:
@@ -205,7 +203,7 @@ struct BoltConnectionResult BoltDirectPool_acquire(struct BoltDirectPool* pool)
 {
     struct BoltConnectionResult handle;
     int index = 0;
-    enum BoltConnectionError pool_error = BOLT_SUCCESS;
+    int pool_error = BOLT_SUCCESS;
 
     int64_t started_at = BoltUtil_get_time_ms();
     BoltLog_info(pool->config->log, "acquiring connection from the pool");

--- a/seabolt/src/bolt/pool/routing-table.c
+++ b/seabolt/src/bolt/pool/routing-table.c
@@ -20,9 +20,10 @@
 #include <assert.h>
 #include <string.h>
 
-#include "routing-table.h"
-#include "bolt/mem.h"
+#include "bolt/config-impl.h"
 #include "bolt/address-set.h"
+#include "bolt/mem.h"
+#include "routing-table.h"
 
 #define READ_ROLE "READ"
 #define WRITE_ROLE "WRITE"

--- a/seabolt/src/bolt/protocol/packstream.c
+++ b/seabolt/src/bolt/protocol/packstream.c
@@ -17,10 +17,11 @@
  * limitations under the License.
  */
 
-#include "packstream.h"
-#include "bolt/connections.h"
+#include "bolt/config-impl.h"
 #include "bolt/buffering.h"
+#include "bolt/connections.h"
 #include "bolt/logging.h"
+#include "packstream.h"
 
 #define TRY(code) { int status_try = (code); if (status_try != BOLT_SUCCESS) { return status_try; } }
 

--- a/seabolt/src/bolt/protocol/protocol.c
+++ b/seabolt/src/bolt/protocol/protocol.c
@@ -17,11 +17,11 @@
  * limitations under the License.
  */
 
-#include "bolt/mem.h"
+#include "bolt/config-impl.h"
 #include "bolt/buffering.h"
-
-#include "protocol.h"
+#include "bolt/mem.h"
 #include "packstream.h"
+#include "protocol.h"
 
 #define BOLT_MAX_CHUNK_SIZE 65535
 

--- a/seabolt/src/bolt/protocol/v1.c
+++ b/seabolt/src/bolt/protocol/v1.c
@@ -17,14 +17,14 @@
  * limitations under the License.
  */
 
-
 #include <assert.h>
 #include <memory.h>
 #include <string.h>
 #include <stdlib.h>
-#include <bolt/connections.h>
 
+#include "bolt/config-impl.h"
 #include "bolt/buffering.h"
+#include "bolt/connections.h"
 #include "bolt/logging.h"
 #include "bolt/mem.h"
 #include "packstream.h"

--- a/seabolt/src/bolt/protocol/v2.c
+++ b/seabolt/src/bolt/protocol/v2.c
@@ -17,8 +17,8 @@
  * limitations under the License.
  */
 
-#include "v2.h"
 #include "v1.h"
+#include "v2.h"
 
 int BoltProtocolV2_check_readable_struct_signature(int16_t signature)
 {

--- a/seabolt/src/bolt/protocol/v3.c
+++ b/seabolt/src/bolt/protocol/v3.c
@@ -19,10 +19,10 @@
 
 #include <string.h>
 
+#include "bolt/config-impl.h"
 #include "bolt/buffering.h"
-#include "bolt/mem.h"
 #include "bolt/logging.h"
-
+#include "bolt/mem.h"
 #include "protocol.h"
 #include "v3.h"
 

--- a/seabolt/src/bolt/tls.c
+++ b/seabolt/src/bolt/tls.c
@@ -17,9 +17,9 @@
  * limitations under the License.
  */
 
-#include "bolt/tls.h"
 #include "bolt/connections.h"
 #include "bolt/logging.h"
+#include "bolt/tls.h"
 
 int verify_callback(int preverify_ok, X509_STORE_CTX* ctx)
 {

--- a/seabolt/src/bolt/utils.c
+++ b/seabolt/src/bolt/utils.c
@@ -20,8 +20,8 @@
 #include <string.h>
 
 #include "bolt/config-impl.h"
-#include "bolt/utils.h"
 #include "bolt/mem.h"
+#include "bolt/utils.h"
 
 struct StringBuilder* StringBuilder_create()
 {

--- a/seabolt/src/bolt/values.c
+++ b/seabolt/src/bolt/values.c
@@ -24,7 +24,6 @@
 
 #include "bolt/mem.h"
 #include "bolt/values.h"
-
 #include "protocol/v1.h"
 
 #define STRING_QUOTE '"'


### PR DESCRIPTION
This PR;

* provides `BoltError_get_string` function to enable upstream users to get human readable error information. 
* activates `BoltConnection.error_ctx` field to hold contextual information (function, file name, line number, actual system call and returned error code) so that upstream users can discover more information about what happened and where.