### PR TITLE
Review parameters and exported functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(seabolt
         DESCRIPTION "The C Connector library for Neo4j"
         LANGUAGES C CXX)
 
-set(SEABOLT_VERSION "1.7.0-rc03" CACHE STRING "The version of seabolt being built")
+set(SEABOLT_VERSION "1.7.0-SNAPSHOT" CACHE STRING "The version of seabolt being built")
 
 message(STATUS ${SEABOLT_VERSION})
 

--- a/src/seabolt-cli/src/main.c
+++ b/src/seabolt-cli/src/main.c
@@ -103,7 +103,7 @@ void timespec_diff(struct timespec* t, struct timespec* t0, struct timespec* t1)
     }
 }
 
-void log_to_stderr(int state, const char* message)
+void log_to_stderr(void* state, const char* message)
 {
     UNUSED(state);
     fprintf(stderr, "%s\n", message);
@@ -323,7 +323,7 @@ int app_run(struct Application* app, const char* cypher)
             if (i>0) {
                 putc('\t', stdout);
             }
-            if (BoltValue_string(BoltList_value(fields, i), string_buffer, 4096, app->connection)>4096) {
+            if (BoltValue_to_string(BoltList_value(fields, i), string_buffer, 4096, app->connection)>4096) {
                 string_buffer[4095] = 0;
             }
             fprintf(stdout, "%s", string_buffer);
@@ -338,7 +338,7 @@ int app_run(struct Application* app, const char* cypher)
             if (i>0) {
                 putc('\t', stdout);
             }
-            if (BoltValue_string(value, string_buffer, 4096, app->connection)>4096) {
+            if (BoltValue_to_string(value, string_buffer, 4096, app->connection)>4096) {
                 string_buffer[4095] = 0;
             }
             fprintf(stdout, "%s", string_buffer);

--- a/src/seabolt-cli/src/main.c
+++ b/src/seabolt-cli/src/main.c
@@ -220,13 +220,15 @@ void app_connect(struct Application* app)
 {
     struct timespec t[2];
     BoltUtil_get_time(&t[0]);
-    struct BoltConnectionResult result = BoltConnector_acquire(app->connector, app->access_mode);
-    if (result.connection==NULL) {
+    BoltStatus* status = BoltStatus_create();
+    BoltConnection* connection = BoltConnector_acquire(app->connector, app->access_mode, status);
+    if (connection==NULL) {
         fprintf(stderr, "FATAL: Failed to connect\n");
         app_destroy(app);
         exit(EXIT_FAILURE);
     }
-    app->connection = result.connection;
+    BoltStatus_destroy(status);
+    app->connection = connection;
     BoltUtil_get_time(&t[1]);
     timespec_diff(&app->stats.connect_time, &t[1], &t[0]);
 }

--- a/src/seabolt/src/bolt/address-private.h
+++ b/src/seabolt/src/bolt/address-private.h
@@ -44,6 +44,6 @@ struct BoltAddress {
 #define BoltAddress_of(host, port) (BoltAddress) { (const char *)host, (const char *)port, 0, NULL, 0, NULL }
 #endif
 
-BoltAddress* BoltAddress_create_from_string(const char* endpoint_str, int32_t endpoint_len);
+BoltAddress* BoltAddress_create_from_string(const char* endpoint_str, uint64_t endpoint_len);
 
 #endif //SEABOLT_ADDRESS_PRIVATE_H

--- a/src/seabolt/src/bolt/address-resolver-private.h
+++ b/src/seabolt/src/bolt/address-resolver-private.h
@@ -22,10 +22,13 @@
 #include "address-resolver.h"
 
 struct BoltAddressResolver {
-    int state;
+    void* state;
     address_resolver_func resolver;
 };
 
 BoltAddressResolver* BoltAddressResolver_clone(BoltAddressResolver* resolver);
+
+void BoltAddressResolver_resolve(BoltAddressResolver* resolver, BoltAddress* address,
+        BoltAddressSet* resolved);
 
 #endif //SEABOLT_ADDRESS_RESOLVER_PRIVATE_H

--- a/src/seabolt/src/bolt/address-resolver.c
+++ b/src/seabolt/src/bolt/address-resolver.c
@@ -21,7 +21,7 @@
 #include "address-resolver-private.h"
 #include "mem.h"
 
-BoltAddressResolver* BoltAddressResolver_create(int state, address_resolver_func resolver_func)
+BoltAddressResolver* BoltAddressResolver_create(void* state, address_resolver_func resolver_func)
 {
     BoltAddressResolver* resolver = (struct BoltAddressResolver*) BoltMem_allocate(sizeof(BoltAddressResolver));
     resolver->state = state;

--- a/src/seabolt/src/bolt/address-resolver.h
+++ b/src/seabolt/src/bolt/address-resolver.h
@@ -23,15 +23,12 @@
 #include "address.h"
 #include "address-set.h"
 
-typedef void (* address_resolver_func)(int state, struct BoltAddress*, struct BoltAddressSet*);
+typedef void (* address_resolver_func)(void* state, struct BoltAddress*, struct BoltAddressSet*);
 
 typedef struct BoltAddressResolver BoltAddressResolver;
 
-SEABOLT_EXPORT BoltAddressResolver* BoltAddressResolver_create(int state, address_resolver_func resolver_func);
+SEABOLT_EXPORT BoltAddressResolver* BoltAddressResolver_create(void* state, address_resolver_func resolver_func);
 
 SEABOLT_EXPORT void BoltAddressResolver_destroy(BoltAddressResolver* resolver);
-
-void BoltAddressResolver_resolve(BoltAddressResolver* resolver, BoltAddress* address,
-        BoltAddressSet* resolved);
 
 #endif //SEABOLT_ALL_SERVER_ADDRESS_RESOLVER_H

--- a/src/seabolt/src/bolt/address-set-private.h
+++ b/src/seabolt/src/bolt/address-set-private.h
@@ -22,11 +22,25 @@
 #include "address-set.h"
 
 struct BoltAddressSet {
-    int size;
+    int32_t size;
     struct BoltAddress** elements;
 };
 
 #define SIZE_OF_ADDRESS_SET sizeof(struct BoltAddressSet)
 #define SIZE_OF_ADDRESS_SET_PTR sizeof(struct BoltAddressSet*)
+
+BoltAddressSet* BoltAddressSet_create();
+
+void BoltAddressSet_destroy(BoltAddressSet* set);
+
+int32_t BoltAddressSet_size(BoltAddressSet* set);
+
+int32_t BoltAddressSet_index_of(BoltAddressSet* set, const BoltAddress* address);
+
+int32_t BoltAddressSet_remove(BoltAddressSet* set, const BoltAddress* address);
+
+void BoltAddressSet_replace(BoltAddressSet* destination, BoltAddressSet* source);
+
+void BoltAddressSet_add_all(BoltAddressSet* destination, BoltAddressSet* source);
 
 #endif //SEABOLT_ADDRESS_SET_PRIVATE_H

--- a/src/seabolt/src/bolt/address-set.c
+++ b/src/seabolt/src/bolt/address-set.c
@@ -39,12 +39,12 @@ void BoltAddressSet_destroy(BoltAddressSet* set)
     BoltMem_deallocate(set, SIZE_OF_ADDRESS_SET);
 }
 
-int BoltAddressSet_size(BoltAddressSet* set)
+int32_t BoltAddressSet_size(BoltAddressSet* set)
 {
     return set->size;
 }
 
-int BoltAddressSet_index_of(BoltAddressSet* set, const BoltAddress* address)
+int32_t BoltAddressSet_index_of(BoltAddressSet* set, const BoltAddress* address)
 {
     for (int i = 0; i<set->size; i++) {
         struct BoltAddress* current = set->elements[i];
@@ -57,7 +57,7 @@ int BoltAddressSet_index_of(BoltAddressSet* set, const BoltAddress* address)
     return -1;
 }
 
-int BoltAddressSet_add(BoltAddressSet* set, const BoltAddress* address)
+int32_t BoltAddressSet_add(BoltAddressSet* set, const BoltAddress* address)
 {
     if (BoltAddressSet_index_of(set, address)==-1) {
         set->elements = (struct BoltAddress**) BoltMem_reallocate(set->elements, set->size*sizeof(BoltAddress*),
@@ -70,7 +70,7 @@ int BoltAddressSet_add(BoltAddressSet* set, const BoltAddress* address)
     return -1;
 }
 
-int BoltAddressSet_remove(BoltAddressSet* set, const BoltAddress* address)
+int32_t BoltAddressSet_remove(BoltAddressSet* set, const BoltAddress* address)
 {
     int index = BoltAddressSet_index_of(set, address);
     if (index>=0) {

--- a/src/seabolt/src/bolt/address-set.h
+++ b/src/seabolt/src/bolt/address-set.h
@@ -24,20 +24,6 @@
 
 typedef struct BoltAddressSet BoltAddressSet;
 
-SEABOLT_EXPORT BoltAddressSet* BoltAddressSet_create();
-
-SEABOLT_EXPORT void BoltAddressSet_destroy(BoltAddressSet* set);
-
-SEABOLT_EXPORT int BoltAddressSet_size(BoltAddressSet* set);
-
-SEABOLT_EXPORT int BoltAddressSet_index_of(BoltAddressSet* set, const BoltAddress* address);
-
-SEABOLT_EXPORT int BoltAddressSet_add(BoltAddressSet* set, const BoltAddress* address);
-
-SEABOLT_EXPORT int BoltAddressSet_remove(BoltAddressSet* set, const BoltAddress* address);
-
-SEABOLT_EXPORT void BoltAddressSet_replace(BoltAddressSet* destination, BoltAddressSet* source);
-
-SEABOLT_EXPORT void BoltAddressSet_add_all(BoltAddressSet* destination, BoltAddressSet* source);
+SEABOLT_EXPORT int32_t BoltAddressSet_add(BoltAddressSet* set, const BoltAddress* address);
 
 #endif //SEABOLT_ALL_ADDRESS_SET_H

--- a/src/seabolt/src/bolt/address.c
+++ b/src/seabolt/src/bolt/address.c
@@ -60,12 +60,8 @@ const char* BoltAddress_port(BoltAddress* address)
     return address->port;
 }
 
-BoltAddress* BoltAddress_create_from_string(const char* endpoint_str, int32_t endpoint_len)
+BoltAddress* BoltAddress_create_from_string(const char* endpoint_str, uint64_t endpoint_len)
 {
-    if (endpoint_len<0) {
-        endpoint_len = (int32_t) strlen(endpoint_str);
-    }
-
     // Create a copy of the string and add null character at the end to properly
     // work with string functions
     char* address_str = (char*) BoltMem_duplicate(endpoint_str, endpoint_len+1);
@@ -85,7 +81,7 @@ BoltAddress* BoltAddress_create_from_string(const char* endpoint_str, int32_t en
     return result;
 }
 
-int BoltAddress_resolve(BoltAddress* address, int* n_resolved, BoltLog* log)
+int32_t BoltAddress_resolve(BoltAddress* address, int32_t* n_resolved, BoltLog* log)
 {
     BoltUtil_mutex_lock(&address->lock);
 
@@ -169,8 +165,8 @@ int BoltAddress_resolve(BoltAddress* address, int* n_resolved, BoltLog* log)
     return gai_status;
 }
 
-int BoltAddress_copy_resolved_host(BoltAddress* address, size_t index, char* buffer,
-        int32_t buffer_size)
+int32_t BoltAddress_copy_resolved_host(BoltAddress* address, int32_t index, char* buffer,
+        uint64_t buffer_size)
 {
     struct sockaddr_storage* resolved_host_storage = &address->resolved_hosts[index];
     const struct sockaddr* resolved_host = (const struct sockaddr*) resolved_host_storage;

--- a/src/seabolt/src/bolt/address.h
+++ b/src/seabolt/src/bolt/address.h
@@ -53,7 +53,7 @@ SEABOLT_EXPORT const char* BoltAddress_port(BoltAddress* address);
  * @param n_resolved pointer to an int value where number of resolved addresses will be saved
  * @return status of the internal getaddrinfo call
  */
-SEABOLT_EXPORT int BoltAddress_resolve(BoltAddress* address, int* n_resolved, struct BoltLog* log);
+SEABOLT_EXPORT int32_t BoltAddress_resolve(BoltAddress* address, int32_t* n_resolved, struct BoltLog* log);
 
 /**
  * Copy the textual representation of a resolved host IP address into a buffer.
@@ -68,8 +68,8 @@ SEABOLT_EXPORT int BoltAddress_resolve(BoltAddress* address, int* n_resolved, st
  * @param buffer_size size of the buffer
  * @return address family (AF_INET or AF_INET6) or -1 on error
  */
-SEABOLT_EXPORT int
-BoltAddress_copy_resolved_host(BoltAddress* address, size_t index, char* buffer, int32_t buffer_size);
+SEABOLT_EXPORT int32_t
+BoltAddress_copy_resolved_host(BoltAddress* address, int32_t index, char* buffer, uint64_t buffer_size);
 
 /**
  * Destroy an address structure and deallocate any associated memory.

--- a/src/seabolt/src/bolt/config-private.h
+++ b/src/seabolt/src/bolt/config-private.h
@@ -23,16 +23,16 @@
 
 struct BoltTrust {
     char* certs;
-	int certs_len;
-    int skip_verify;
-    int skip_verify_hostname;
+	uint64_t certs_len;
+    int32_t skip_verify;
+    int32_t skip_verify_hostname;
 };
 
 struct BoltSocketOptions {
-    int connect_timeout;
-    int recv_timeout;
-    int send_timeout;
-    int keep_alive;
+	int32_t connect_timeout;
+	int32_t recv_timeout;
+	int32_t send_timeout;
+	int32_t keep_alive;
 };
 
 struct BoltConfig {
@@ -43,9 +43,9 @@ struct BoltConfig {
     struct BoltValue* routing_context;
     struct BoltAddressResolver* address_resolver;
     struct BoltLog* log;
-    int max_pool_size;
-    int max_connection_life_time;
-    int max_connection_acquisition_time;
+	int32_t max_pool_size;
+	int32_t max_connection_life_time;
+	int32_t max_connection_acquisition_time;
     struct BoltSocketOptions* socket_options;
 };
 

--- a/src/seabolt/src/bolt/config.c
+++ b/src/seabolt/src/bolt/config.c
@@ -52,23 +52,23 @@ void BoltSocketOptions_destroy(BoltSocketOptions* socket_options)
     BoltMem_deallocate(socket_options, sizeof(BoltSocketOptions));
 }
 
-int BoltSocketOptions_get_connect_timeout(BoltSocketOptions* socket_options)
+int32_t BoltSocketOptions_get_connect_timeout(BoltSocketOptions* socket_options)
 {
     return socket_options->connect_timeout;
 }
 
-int BoltSocketOptions_set_connect_timeout(BoltSocketOptions* socket_options, int connect_timeout)
+int32_t BoltSocketOptions_set_connect_timeout(BoltSocketOptions* socket_options, int32_t connect_timeout)
 {
     socket_options->connect_timeout = connect_timeout;
     return BOLT_SUCCESS;
 }
 
-int BoltSocketOptions_get_keep_alive(BoltSocketOptions* socket_options)
+int32_t BoltSocketOptions_get_keep_alive(BoltSocketOptions* socket_options)
 {
     return socket_options->keep_alive;
 }
 
-int BoltSocketOptions_set_keep_alive(BoltSocketOptions* socket_options, int keep_alive)
+int32_t BoltSocketOptions_set_keep_alive(BoltSocketOptions* socket_options, int32_t keep_alive)
 {
     socket_options->keep_alive = keep_alive;
     return BOLT_SUCCESS;
@@ -105,36 +105,36 @@ void BoltTrust_destroy(BoltTrust* trust)
     BoltMem_deallocate(trust, sizeof(BoltTrust));
 }
 
-const char* BoltTrust_get_certs(BoltTrust* trust, size_t* size)
+const char* BoltTrust_get_certs(BoltTrust* trust, uint64_t* size)
 {
     *size = trust->certs_len;
     return trust->certs;
 }
 
-int BoltTrust_set_certs(BoltTrust* trust, const char* certs_pem, int certs_pem_size)
+int32_t BoltTrust_set_certs(BoltTrust* trust, const char* certs_pem, uint64_t certs_pem_size)
 {
     trust->certs = BoltMem_duplicate(certs_pem, certs_pem_size);
     trust->certs_len = certs_pem_size;
     return BOLT_SUCCESS;
 }
 
-int BoltTrust_get_skip_verify(BoltTrust* trust)
+int32_t BoltTrust_get_skip_verify(BoltTrust* trust)
 {
     return trust->skip_verify;
 }
 
-int BoltTrust_set_skip_verify(BoltTrust* trust, int skip_verify)
+int32_t BoltTrust_set_skip_verify(BoltTrust* trust, int32_t skip_verify)
 {
     trust->skip_verify = skip_verify;
     return BOLT_SUCCESS;
 }
 
-int BoltTrust_get_skip_verify_hostname(BoltTrust* trust)
+int32_t BoltTrust_get_skip_verify_hostname(BoltTrust* trust)
 {
     return trust->skip_verify_hostname;
 }
 
-int BoltTrust_set_skip_verify_hostname(BoltTrust* trust, int skip_verify_hostname)
+int32_t BoltTrust_set_skip_verify_hostname(BoltTrust* trust, int32_t skip_verify_hostname)
 {
     trust->skip_verify_hostname = skip_verify_hostname;
     return BOLT_SUCCESS;
@@ -204,7 +204,7 @@ BoltMode BoltConfig_get_mode(BoltConfig* config)
     return config->mode;
 }
 
-int BoltConfig_set_mode(BoltConfig* config, BoltMode mode)
+int32_t BoltConfig_set_mode(BoltConfig* config, BoltMode mode)
 {
     config->mode = mode;
     return BOLT_SUCCESS;
@@ -215,7 +215,7 @@ BoltTransport BoltConfig_get_transport(BoltConfig* config)
     return config->transport;
 }
 
-int BoltConfig_set_transport(BoltConfig* config, BoltTransport transport)
+int32_t BoltConfig_set_transport(BoltConfig* config, BoltTransport transport)
 {
     config->transport = transport;
     return BOLT_SUCCESS;
@@ -226,7 +226,7 @@ BoltTrust* BoltConfig_get_trust(BoltConfig* config)
     return config->trust;
 }
 
-int BoltConfig_set_trust(BoltConfig* config, BoltTrust* trust)
+int32_t BoltConfig_set_trust(BoltConfig* config, BoltTrust* trust)
 {
     config->trust = BoltTrust_clone(trust);
     return BOLT_SUCCESS;
@@ -237,7 +237,7 @@ const char* BoltConfig_get_user_agent(BoltConfig* config)
     return config->user_agent;
 }
 
-int BoltConfig_set_user_agent(BoltConfig* config, const char* user_agent)
+int32_t BoltConfig_set_user_agent(BoltConfig* config, const char* user_agent)
 {
     config->user_agent = BoltMem_duplicate(user_agent, SIZE_OF_C_STRING(user_agent));
     return BOLT_SUCCESS;
@@ -248,7 +248,7 @@ BoltValue* BoltConfig_get_routing_context(BoltConfig* config)
     return config->routing_context;
 }
 
-int BoltConfig_set_routing_context(BoltConfig* config, BoltValue* routing_context)
+int32_t BoltConfig_set_routing_context(BoltConfig* config, BoltValue* routing_context)
 {
     config->routing_context = BoltValue_duplicate(routing_context);
     return BOLT_SUCCESS;
@@ -259,7 +259,7 @@ BoltAddressResolver* BoltConfig_get_address_resolver(BoltConfig* config)
     return config->address_resolver;
 }
 
-int BoltConfig_set_address_resolver(BoltConfig* config, BoltAddressResolver* address_resolver)
+int32_t BoltConfig_set_address_resolver(BoltConfig* config, BoltAddressResolver* address_resolver)
 {
     config->address_resolver = BoltAddressResolver_clone(address_resolver);
     return BOLT_SUCCESS;
@@ -270,40 +270,40 @@ BoltLog* BoltConfig_get_log(BoltConfig* config)
     return config->log;
 }
 
-int BoltConfig_set_log(BoltConfig* config, BoltLog* log)
+int32_t BoltConfig_set_log(BoltConfig* config, BoltLog* log)
 {
     config->log = BoltLog_clone(log);
     return BOLT_SUCCESS;
 }
 
-int BoltConfig_get_max_pool_size(BoltConfig* config)
+int32_t BoltConfig_get_max_pool_size(BoltConfig* config)
 {
     return config->max_pool_size;
 }
 
-int BoltConfig_set_max_pool_size(BoltConfig* config, int max_pool_size)
+int32_t BoltConfig_set_max_pool_size(BoltConfig* config, int32_t max_pool_size)
 {
     config->max_pool_size = max_pool_size;
     return BOLT_SUCCESS;
 }
 
-int BoltConfig_get_max_connection_life_time(BoltConfig* config)
+int32_t BoltConfig_get_max_connection_life_time(BoltConfig* config)
 {
     return config->max_connection_life_time;
 }
 
-int BoltConfig_set_max_connection_life_time(BoltConfig* config, int max_connection_life_time)
+int32_t BoltConfig_set_max_connection_life_time(BoltConfig* config, int32_t max_connection_life_time)
 {
     config->max_connection_life_time = max_connection_life_time;
     return BOLT_SUCCESS;
 }
 
-int BoltConfig_get_max_connection_acquisition_time(BoltConfig* config)
+int32_t BoltConfig_get_max_connection_acquisition_time(BoltConfig* config)
 {
     return config->max_connection_acquisition_time;
 }
 
-int BoltConfig_set_max_connection_acquisition_time(BoltConfig* config, int max_connection_acquisition_time)
+int32_t BoltConfig_set_max_connection_acquisition_time(BoltConfig* config, int32_t max_connection_acquisition_time)
 {
     config->max_connection_acquisition_time = max_connection_acquisition_time;
     return BOLT_SUCCESS;
@@ -314,7 +314,7 @@ BoltSocketOptions* BoltConfig_get_socket_options(BoltConfig* config)
     return config->socket_options;
 }
 
-int BoltConfig_set_socket_options(BoltConfig* config, BoltSocketOptions* socket_options)
+int32_t BoltConfig_set_socket_options(BoltConfig* config, BoltSocketOptions* socket_options)
 {
     config->socket_options = BoltSocketOptions_clone(socket_options);
     return BOLT_SUCCESS;

--- a/src/seabolt/src/bolt/config.h
+++ b/src/seabolt/src/bolt/config.h
@@ -23,11 +23,11 @@
 #include "address-resolver.h"
 #include "values.h"
 
-typedef int BoltMode;
+typedef int32_t BoltMode;
 #define BOLT_MODE_DIRECT    0
 #define BOLT_MODE_ROUTING   1
 
-typedef int BoltTransport;
+typedef int32_t BoltTransport;
 #define BOLT_TRANSPORT_PLAINTEXT    0
 #define BOLT_TRANSPORT_ENCRYPTED    1
 
@@ -40,13 +40,13 @@ SEABOLT_EXPORT BoltSocketOptions* BoltSocketOptions_create();
 
 SEABOLT_EXPORT void BoltSocketOptions_destroy(BoltSocketOptions* socket_options);
 
-SEABOLT_EXPORT int BoltSocketOptions_get_connect_timeout(BoltSocketOptions* socket_options);
+SEABOLT_EXPORT int32_t BoltSocketOptions_get_connect_timeout(BoltSocketOptions* socket_options);
 
-SEABOLT_EXPORT int BoltSocketOptions_set_connect_timeout(BoltSocketOptions* socket_options, int connect_timeout);
+SEABOLT_EXPORT int32_t BoltSocketOptions_set_connect_timeout(BoltSocketOptions* socket_options, int32_t connect_timeout);
 
-SEABOLT_EXPORT int BoltSocketOptions_get_keep_alive(BoltSocketOptions* socket_options);
+SEABOLT_EXPORT int32_t BoltSocketOptions_get_keep_alive(BoltSocketOptions* socket_options);
 
-SEABOLT_EXPORT int BoltSocketOptions_set_keep_alive(BoltSocketOptions* socket_options, int keep_alive);
+SEABOLT_EXPORT int32_t BoltSocketOptions_set_keep_alive(BoltSocketOptions* socket_options, int32_t keep_alive);
 
 /**
  * Trust options
@@ -57,17 +57,17 @@ SEABOLT_EXPORT BoltTrust* BoltTrust_create();
 
 SEABOLT_EXPORT void BoltTrust_destroy(BoltTrust* trust);
 
-SEABOLT_EXPORT const char* BoltTrust_get_certs(BoltTrust* trust, size_t* size);
+SEABOLT_EXPORT const char* BoltTrust_get_certs(BoltTrust* trust, uint64_t* size);
 
-SEABOLT_EXPORT int BoltTrust_set_certs(BoltTrust* trust, const char* certs_pem, int certs_pem_size);
+SEABOLT_EXPORT int32_t BoltTrust_set_certs(BoltTrust* trust, const char* certs_pem, uint64_t certs_pem_size);
 
-SEABOLT_EXPORT int BoltTrust_get_skip_verify(BoltTrust* trust);
+SEABOLT_EXPORT int32_t BoltTrust_get_skip_verify(BoltTrust* trust);
 
-SEABOLT_EXPORT int BoltTrust_set_skip_verify(BoltTrust* trust, int skip_verify);
+SEABOLT_EXPORT int32_t BoltTrust_set_skip_verify(BoltTrust* trust, int32_t skip_verify);
 
-SEABOLT_EXPORT int BoltTrust_get_skip_verify_hostname(BoltTrust* trust);
+SEABOLT_EXPORT int32_t BoltTrust_get_skip_verify_hostname(BoltTrust* trust);
 
-SEABOLT_EXPORT int BoltTrust_set_skip_verify_hostname(BoltTrust* trust, int skip_verify_hostname);
+SEABOLT_EXPORT int32_t BoltTrust_set_skip_verify_hostname(BoltTrust* trust, int32_t skip_verify_hostname);
 
 /**
  * Configuration options
@@ -80,47 +80,47 @@ SEABOLT_EXPORT void BoltConfig_destroy(BoltConfig* config);
 
 SEABOLT_EXPORT BoltMode BoltConfig_get_mode(BoltConfig* config);
 
-SEABOLT_EXPORT int BoltConfig_set_mode(BoltConfig* config, BoltMode mode);
+SEABOLT_EXPORT int32_t BoltConfig_set_mode(BoltConfig* config, BoltMode mode);
 
 SEABOLT_EXPORT BoltTransport BoltConfig_get_transport(BoltConfig* config);
 
-SEABOLT_EXPORT int BoltConfig_set_transport(BoltConfig* config, BoltTransport transport);
+SEABOLT_EXPORT int32_t BoltConfig_set_transport(BoltConfig* config, BoltTransport transport);
 
 SEABOLT_EXPORT BoltTrust* BoltConfig_get_trust(BoltConfig* config);
 
-SEABOLT_EXPORT int BoltConfig_set_trust(BoltConfig* config, BoltTrust* trust);
+SEABOLT_EXPORT int32_t BoltConfig_set_trust(BoltConfig* config, BoltTrust* trust);
 
 SEABOLT_EXPORT const char* BoltConfig_get_user_agent(BoltConfig* config);
 
-SEABOLT_EXPORT int BoltConfig_set_user_agent(BoltConfig* config, const char* user_agent);
+SEABOLT_EXPORT int32_t BoltConfig_set_user_agent(BoltConfig* config, const char* user_agent);
 
 SEABOLT_EXPORT BoltValue* BoltConfig_get_routing_context(BoltConfig* config);
 
-SEABOLT_EXPORT int BoltConfig_set_routing_context(BoltConfig* config, BoltValue* routing_context);
+SEABOLT_EXPORT int32_t BoltConfig_set_routing_context(BoltConfig* config, BoltValue* routing_context);
 
 SEABOLT_EXPORT BoltAddressResolver* BoltConfig_get_address_resolver(BoltConfig* config);
 
-SEABOLT_EXPORT int BoltConfig_set_address_resolver(BoltConfig* config, BoltAddressResolver* address_resolver);
+SEABOLT_EXPORT int32_t BoltConfig_set_address_resolver(BoltConfig* config, BoltAddressResolver* address_resolver);
 
 SEABOLT_EXPORT BoltLog* BoltConfig_get_log(BoltConfig* config);
 
-SEABOLT_EXPORT int BoltConfig_set_log(BoltConfig* config, BoltLog* log);
+SEABOLT_EXPORT int32_t BoltConfig_set_log(BoltConfig* config, BoltLog* log);
 
-SEABOLT_EXPORT int BoltConfig_get_max_pool_size(BoltConfig* config);
+SEABOLT_EXPORT int32_t BoltConfig_get_max_pool_size(BoltConfig* config);
 
-SEABOLT_EXPORT int BoltConfig_set_max_pool_size(BoltConfig* config, int max_pool_size);
+SEABOLT_EXPORT int32_t BoltConfig_set_max_pool_size(BoltConfig* config, int32_t max_pool_size);
 
-SEABOLT_EXPORT int BoltConfig_get_max_connection_life_time(BoltConfig* config);
+SEABOLT_EXPORT int32_t BoltConfig_get_max_connection_life_time(BoltConfig* config);
 
-SEABOLT_EXPORT int BoltConfig_set_max_connection_life_time(BoltConfig* config, int max_connection_life_time);
+SEABOLT_EXPORT int32_t BoltConfig_set_max_connection_life_time(BoltConfig* config, int32_t max_connection_life_time);
 
-SEABOLT_EXPORT int BoltConfig_get_max_connection_acquisition_time(BoltConfig* config);
+SEABOLT_EXPORT int32_t BoltConfig_get_max_connection_acquisition_time(BoltConfig* config);
 
-SEABOLT_EXPORT int
-BoltConfig_set_max_connection_acquisition_time(BoltConfig* config, int max_connection_acquisition_time);
+SEABOLT_EXPORT int32_t
+BoltConfig_set_max_connection_acquisition_time(BoltConfig* config, int32_t max_connection_acquisition_time);
 
 SEABOLT_EXPORT BoltSocketOptions* BoltConfig_get_socket_options(BoltConfig* config);
 
-SEABOLT_EXPORT int BoltConfig_set_socket_options(BoltConfig* config, BoltSocketOptions* socket_options);
+SEABOLT_EXPORT int32_t BoltConfig_set_socket_options(BoltConfig* config, BoltSocketOptions* socket_options);
 
 #endif //SEABOLT_CONFIG_H

--- a/src/seabolt/src/bolt/connection-private.h
+++ b/src/seabolt/src/bolt/connection-private.h
@@ -84,4 +84,15 @@ struct BoltConnection {
     void* on_error_cb_state;
 };
 
+/**
+ * Take an exact amount of data from the receive buffer, deferring to
+ * the socket if not enough data is available.
+ *
+ * @param connection
+ * @param buffer
+ * @param buffer_size
+ * @return
+ */
+int32_t BoltConnection_receive(BoltConnection* connection, char* buffer, int buffer_size);
+
 #endif //SEABOLT_CONNECTION_PRIVATE_H

--- a/src/seabolt/src/bolt/connection.c
+++ b/src/seabolt/src/bolt/connection.c
@@ -697,7 +697,7 @@ BoltConnection* BoltConnection_create()
     const size_t size = sizeof(BoltConnection);
     BoltConnection* connection = BoltMem_allocate(size);
     memset(connection, 0, size);
-    connection->status = BoltStatus_create(ERROR_CTX_SIZE);
+    connection->status = BoltStatus_create_with_ctx(ERROR_CTX_SIZE);
     connection->metrics = BoltMem_allocate(sizeof(BoltConnectionMetrics));
     return connection;
 }

--- a/src/seabolt/src/bolt/connection.c
+++ b/src/seabolt/src/bolt/connection.c
@@ -713,7 +713,7 @@ void BoltConnection_destroy(BoltConnection* connection)
     BoltMem_deallocate(connection, sizeof(BoltConnection));
 }
 
-int
+int32_t
 BoltConnection_open(BoltConnection* connection, BoltTransport transport, struct BoltAddress* address,
         struct BoltTrust* trust, struct BoltLog* log, struct BoltSocketOptions* sock_opts)
 {
@@ -811,7 +811,7 @@ void BoltConnection_close(BoltConnection* connection)
     }
 }
 
-int BoltConnection_send(BoltConnection* connection)
+int32_t BoltConnection_send(BoltConnection* connection)
 {
     int size = BoltBuffer_unloadable(connection->tx_buffer);
     TRY(_send(connection, BoltBuffer_unload_pointer(connection->tx_buffer, size), size),
@@ -876,7 +876,7 @@ int BoltConnection_fetch(BoltConnection* connection, BoltRequest request)
     return fetched;
 }
 
-int BoltConnection_fetch_summary(BoltConnection* connection, BoltRequest request)
+int32_t BoltConnection_fetch_summary(BoltConnection* connection, BoltRequest request)
 {
     int records = 0;
     int data;
@@ -896,17 +896,17 @@ struct BoltValue* BoltConnection_field_values(BoltConnection* connection)
     return connection->protocol->field_values(connection);
 }
 
-int BoltConnection_summary_success(BoltConnection* connection)
+int32_t BoltConnection_summary_success(BoltConnection* connection)
 {
     return connection->protocol->is_success_summary(connection);
 }
 
-int BoltConnection_summary_failure(BoltConnection* connection)
+int32_t BoltConnection_summary_failure(BoltConnection* connection)
 {
     return connection->protocol->is_failure_summary(connection);
 }
 
-int
+int32_t
 BoltConnection_init(BoltConnection* connection, const char* user_agent, const struct BoltValue* auth_token)
 {
     BoltLog_info(connection->log, "[%s]: Initialising connection", BoltConnection_id(connection));
@@ -939,35 +939,35 @@ BoltConnection_init(BoltConnection* connection, const char* user_agent, const st
     }
 }
 
-int BoltConnection_clear_begin(BoltConnection* connection)
+int32_t BoltConnection_clear_begin(BoltConnection* connection)
 {
     TRY(connection->protocol->clear_begin_tx(connection), "BoltConnection_clear_begin(%s:%d), error code: %d", __FILE__,
             __LINE__);
     return BOLT_SUCCESS;
 }
 
-int BoltConnection_set_begin_bookmarks(BoltConnection* connection, struct BoltValue* bookmark_list)
+int32_t BoltConnection_set_begin_bookmarks(BoltConnection* connection, struct BoltValue* bookmark_list)
 {
     TRY(connection->protocol->set_begin_tx_bookmark(connection, bookmark_list),
             "BoltConnection_set_begin_bookmarks(%s:%d), error code: %d", __FILE__, __LINE__);
     return BOLT_SUCCESS;
 }
 
-int BoltConnection_set_begin_tx_timeout(BoltConnection* connection, int64_t timeout)
+int32_t BoltConnection_set_begin_tx_timeout(BoltConnection* connection, int64_t timeout)
 {
     TRY(connection->protocol->set_begin_tx_timeout(connection, timeout),
             "BoltConnection_set_begin_tx_timeout(%s:%d), error code: %d", __FILE__, __LINE__);
     return BOLT_SUCCESS;
 }
 
-int BoltConnection_set_begin_tx_metadata(BoltConnection* connection, struct BoltValue* metadata)
+int32_t BoltConnection_set_begin_tx_metadata(BoltConnection* connection, struct BoltValue* metadata)
 {
     TRY(connection->protocol->set_begin_tx_metadata(connection, metadata),
             "BoltConnection_set_begin_tx_metadata(%s:%d), error code: %d", __FILE__, __LINE__);
     return BOLT_SUCCESS;
 }
 
-int BoltConnection_load_begin_request(BoltConnection* connection)
+int32_t BoltConnection_load_begin_request(BoltConnection* connection)
 {
     TRY(connection->protocol->load_begin_tx(connection), "BoltConnection_load_begin_request(%s:%d), error code: %d",
             __FILE__,
@@ -975,7 +975,7 @@ int BoltConnection_load_begin_request(BoltConnection* connection)
     return BOLT_SUCCESS;
 }
 
-int BoltConnection_load_commit_request(BoltConnection* connection)
+int32_t BoltConnection_load_commit_request(BoltConnection* connection)
 {
     TRY(connection->protocol->load_commit_tx(connection), "BoltConnection_load_commit_request(%s:%d), error code: %d",
             __FILE__,
@@ -983,7 +983,7 @@ int BoltConnection_load_commit_request(BoltConnection* connection)
     return BOLT_SUCCESS;
 }
 
-int BoltConnection_load_rollback_request(BoltConnection* connection)
+int32_t BoltConnection_load_rollback_request(BoltConnection* connection)
 {
     TRY(connection->protocol->load_rollback_tx(connection),
             "BoltConnection_load_rollback_request(%s:%d), error code: %d",
@@ -991,16 +991,16 @@ int BoltConnection_load_rollback_request(BoltConnection* connection)
     return BOLT_SUCCESS;
 }
 
-int BoltConnection_clear_run(BoltConnection* connection)
+int32_t BoltConnection_clear_run(BoltConnection* connection)
 {
     TRY(connection->protocol->clear_run(connection), "BoltConnection_clear_run(%s:%d), error code: %d", __FILE__,
             __LINE__);
     return BOLT_SUCCESS;
 }
 
-int
-BoltConnection_set_run_cypher(BoltConnection* connection, const char* cypher, const size_t cypher_size,
-        int32_t n_parameter)
+int32_t
+BoltConnection_set_run_cypher(BoltConnection* connection, const char* cypher, const uint64_t cypher_size,
+        const int32_t n_parameter)
 {
     TRY(connection->protocol->set_run_cypher(connection, cypher, cypher_size, n_parameter),
             "BoltConnection_set_run_cypher(%s:%d), error code: %d", __FILE__, __LINE__);
@@ -1009,54 +1009,54 @@ BoltConnection_set_run_cypher(BoltConnection* connection, const char* cypher, co
 
 struct BoltValue*
 BoltConnection_set_run_cypher_parameter(BoltConnection* connection, int32_t index, const char* name,
-        size_t name_size)
+        const uint64_t name_size)
 {
     return connection->protocol->set_run_cypher_parameter(connection, index, name, name_size);
 }
 
-int BoltConnection_set_run_bookmarks(BoltConnection* connection, struct BoltValue* bookmark_list)
+int32_t BoltConnection_set_run_bookmarks(BoltConnection* connection, struct BoltValue* bookmark_list)
 {
     TRY(connection->protocol->set_run_bookmark(connection, bookmark_list),
             "BoltConnection_set_run_bookmarks(%s:%d), error code: %d", __FILE__, __LINE__);
     return BOLT_SUCCESS;
 }
 
-int BoltConnection_set_run_tx_timeout(BoltConnection* connection, int64_t timeout)
+int32_t BoltConnection_set_run_tx_timeout(BoltConnection* connection, int64_t timeout)
 {
     TRY(connection->protocol->set_run_tx_timeout(connection, timeout),
             "BoltConnection_set_run_tx_timeout(%s:%d), error code: %d", __FILE__, __LINE__);
     return BOLT_SUCCESS;
 }
 
-int BoltConnection_set_run_tx_metadata(BoltConnection* connection, struct BoltValue* metadata)
+int32_t BoltConnection_set_run_tx_metadata(BoltConnection* connection, struct BoltValue* metadata)
 {
     TRY(connection->protocol->set_run_tx_metadata(connection, metadata),
             "BoltConnection_set_run_tx_metadata(%s:%d), error code: %d", __FILE__, __LINE__);
     return BOLT_SUCCESS;
 }
 
-int BoltConnection_load_run_request(BoltConnection* connection)
+int32_t BoltConnection_load_run_request(BoltConnection* connection)
 {
     TRY(connection->protocol->load_run(connection), "BoltConnection_load_run_request(%s:%d), error code: %d", __FILE__,
             __LINE__);
     return BOLT_SUCCESS;
 }
 
-int BoltConnection_load_discard_request(BoltConnection* connection, int32_t n)
+int32_t BoltConnection_load_discard_request(BoltConnection* connection, int32_t n)
 {
     TRY(connection->protocol->load_discard(connection, n), "BoltConnection_load_discard_request(%s:%d), error code: %d",
             __FILE__, __LINE__);
     return BOLT_SUCCESS;
 }
 
-int BoltConnection_load_pull_request(BoltConnection* connection, int32_t n)
+int32_t BoltConnection_load_pull_request(BoltConnection* connection, int32_t n)
 {
     TRY(connection->protocol->load_pull(connection, n), "BoltConnection_load_pull_request(%s:%d), error code: %d",
             __FILE__, __LINE__);
     return BOLT_SUCCESS;
 }
 
-int BoltConnection_load_reset_request(BoltConnection* connection)
+int32_t BoltConnection_load_reset_request(BoltConnection* connection)
 {
     TRY(connection->protocol->load_reset(connection), "BoltConnection_load_reset_request(%s:%d), error code: %d",
             __FILE__, __LINE__);
@@ -1068,12 +1068,12 @@ BoltRequest BoltConnection_last_request(BoltConnection* connection)
     return connection->protocol->last_request(connection);
 }
 
-char* BoltConnection_server(BoltConnection* connection)
+const char* BoltConnection_server(BoltConnection* connection)
 {
     return connection->protocol->server(connection);
 }
 
-char* BoltConnection_id(BoltConnection* connection)
+const char* BoltConnection_id(BoltConnection* connection)
 {
     if (connection->protocol!=NULL && connection->protocol->id!=NULL) {
         return connection->protocol->id(connection);
@@ -1097,7 +1097,7 @@ const BoltAddress* BoltConnection_local_endpoint(BoltConnection* connection)
     return connection->local_address;
 }
 
-char* BoltConnection_last_bookmark(BoltConnection* connection)
+const char* BoltConnection_last_bookmark(BoltConnection* connection)
 {
     return connection->protocol->last_bookmark(connection);
 }

--- a/src/seabolt/src/bolt/connection.h
+++ b/src/seabolt/src/bolt/connection.h
@@ -85,7 +85,7 @@ SEABOLT_EXPORT void BoltConnection_destroy(BoltConnection* connection);
  * @param address descriptor of the remote Bolt server address
  * @return 0 if the connection was opened successfully, -1 otherwise
  */
-SEABOLT_EXPORT int BoltConnection_open(BoltConnection* connection, BoltTransport transport,
+SEABOLT_EXPORT int32_t BoltConnection_open(BoltConnection* connection, BoltTransport transport,
         BoltAddress* address, struct BoltTrust* trust, struct BoltLog* log, struct BoltSocketOptions* sock_opts);
 
 /**
@@ -104,7 +104,7 @@ SEABOLT_EXPORT void BoltConnection_close(BoltConnection* connection);
  * @param auth_token dictionary that contains user credentials
  * @return
  */
-SEABOLT_EXPORT int
+SEABOLT_EXPORT int32_t
 BoltConnection_init(BoltConnection* connection, const char* user_agent, const BoltValue* auth_token);
 
 /**
@@ -113,18 +113,7 @@ BoltConnection_init(BoltConnection* connection, const char* user_agent, const Bo
  * @param connection
  * @return the latest request ID
  */
-SEABOLT_EXPORT int BoltConnection_send(BoltConnection* connection);
-
-/**
- * Take an exact amount of data from the receive buffer, deferring to
- * the socket if not enough data is available.
- *
- * @param connection
- * @param buffer
- * @param size
- * @return
- */
-int BoltConnection_receive(BoltConnection* connection, char* buffer, int size);
+SEABOLT_EXPORT int32_t BoltConnection_send(BoltConnection* connection);
 
 /**
  * Fetch the next value from the result stream for a given request.
@@ -147,7 +136,7 @@ int BoltConnection_receive(BoltConnection* connection, char* buffer, int size);
  *         -1 if an error occurs
  *
  */
-SEABOLT_EXPORT int BoltConnection_fetch(BoltConnection* connection, BoltRequest request);
+SEABOLT_EXPORT int32_t BoltConnection_fetch(BoltConnection* connection, BoltRequest request);
 
 /**
  * Fetch values from the result stream for a given request, up to and
@@ -167,7 +156,7 @@ SEABOLT_EXPORT int BoltConnection_fetch(BoltConnection* connection, BoltRequest 
  * @return >=0 the number of records discarded from this result
  *         -1 if an error occurs
  */
-SEABOLT_EXPORT int BoltConnection_fetch_summary(BoltConnection* connection, BoltRequest request);
+SEABOLT_EXPORT int32_t BoltConnection_fetch_summary(BoltConnection* connection, BoltRequest request);
 
 /**
  * Load a transaction BEGIN request into the request queue.
@@ -175,13 +164,13 @@ SEABOLT_EXPORT int BoltConnection_fetch_summary(BoltConnection* connection, Bolt
  * @param connection
  * @return
  */
-SEABOLT_EXPORT int BoltConnection_clear_begin(BoltConnection* connection);
+SEABOLT_EXPORT int32_t BoltConnection_clear_begin(BoltConnection* connection);
 
-SEABOLT_EXPORT int BoltConnection_set_begin_bookmarks(BoltConnection* connection, BoltValue* bookmark_list);
+SEABOLT_EXPORT int32_t BoltConnection_set_begin_bookmarks(BoltConnection* connection, BoltValue* bookmark_list);
 
-SEABOLT_EXPORT int BoltConnection_set_begin_tx_timeout(BoltConnection* connection, int64_t timeout);
+SEABOLT_EXPORT int32_t BoltConnection_set_begin_tx_timeout(BoltConnection* connection, int64_t timeout);
 
-SEABOLT_EXPORT int BoltConnection_set_begin_tx_metadata(BoltConnection* connection, BoltValue* metadata);
+SEABOLT_EXPORT int32_t BoltConnection_set_begin_tx_metadata(BoltConnection* connection, BoltValue* metadata);
 
 /**
  * Load a transaction BEGIN request into the request queue.
@@ -189,7 +178,7 @@ SEABOLT_EXPORT int BoltConnection_set_begin_tx_metadata(BoltConnection* connecti
  * @param connection
  * @return
  */
-SEABOLT_EXPORT int BoltConnection_load_begin_request(BoltConnection* connection);
+SEABOLT_EXPORT int32_t BoltConnection_load_begin_request(BoltConnection* connection);
 
 /**
  * Load a transaction COMMIT request into the request queue.
@@ -197,7 +186,7 @@ SEABOLT_EXPORT int BoltConnection_load_begin_request(BoltConnection* connection)
  * @param connection
  * @return
  */
-SEABOLT_EXPORT int BoltConnection_load_commit_request(BoltConnection* connection);
+SEABOLT_EXPORT int32_t BoltConnection_load_commit_request(BoltConnection* connection);
 
 /**
  * Load a transaction ROLLBACK request into the request queue.
@@ -205,7 +194,7 @@ SEABOLT_EXPORT int BoltConnection_load_commit_request(BoltConnection* connection
  * @param connection
  * @return
  */
-SEABOLT_EXPORT int BoltConnection_load_rollback_request(BoltConnection* connection);
+SEABOLT_EXPORT int32_t BoltConnection_load_rollback_request(BoltConnection* connection);
 
 /**
  * Load a RUN request into the request queue.
@@ -213,23 +202,23 @@ SEABOLT_EXPORT int BoltConnection_load_rollback_request(BoltConnection* connecti
  * @param connection
  * @return
  */
-SEABOLT_EXPORT int BoltConnection_clear_run(BoltConnection* connection);
+SEABOLT_EXPORT int32_t BoltConnection_clear_run(BoltConnection* connection);
 
-SEABOLT_EXPORT int BoltConnection_set_run_bookmarks(BoltConnection* connection, BoltValue* bookmark_list);
+SEABOLT_EXPORT int32_t BoltConnection_set_run_bookmarks(BoltConnection* connection, BoltValue* bookmark_list);
 
-SEABOLT_EXPORT int BoltConnection_set_run_tx_timeout(BoltConnection* connection, int64_t timeout);
+SEABOLT_EXPORT int32_t BoltConnection_set_run_tx_timeout(BoltConnection* connection, int64_t timeout);
 
-SEABOLT_EXPORT int BoltConnection_set_run_tx_metadata(BoltConnection* connection, BoltValue* metadata);
+SEABOLT_EXPORT int32_t BoltConnection_set_run_tx_metadata(BoltConnection* connection, BoltValue* metadata);
 
 SEABOLT_EXPORT int
-BoltConnection_set_run_cypher(BoltConnection* connection, const char* cypher, const size_t cypher_size,
-        int32_t n_parameter);
+BoltConnection_set_run_cypher(BoltConnection* connection, const char* cypher, const uint64_t cypher_size,
+        const int32_t n_parameter);
 
 SEABOLT_EXPORT BoltValue*
 BoltConnection_set_run_cypher_parameter(BoltConnection* connection, int32_t index, const char* name,
-        size_t name_size);
+        const uint64_t name_size);
 
-SEABOLT_EXPORT int BoltConnection_load_run_request(BoltConnection* connection);
+SEABOLT_EXPORT int32_t BoltConnection_load_run_request(BoltConnection* connection);
 
 /**
  * Load a DISCARD_ALL request into the request queue.
@@ -238,7 +227,7 @@ SEABOLT_EXPORT int BoltConnection_load_run_request(BoltConnection* connection);
  * @param n should always be -1
  * @return
  */
-SEABOLT_EXPORT int BoltConnection_load_discard_request(BoltConnection* connection, int32_t n);
+SEABOLT_EXPORT int32_t BoltConnection_load_discard_request(BoltConnection* connection, int32_t n);
 
 /**
  * Load a PULL_ALL request into the request queue.
@@ -247,7 +236,7 @@ SEABOLT_EXPORT int BoltConnection_load_discard_request(BoltConnection* connectio
  * @param n should always be -1
  * @return
  */
-SEABOLT_EXPORT int BoltConnection_load_pull_request(BoltConnection* connection, int32_t n);
+SEABOLT_EXPORT int32_t BoltConnection_load_pull_request(BoltConnection* connection, int32_t n);
 
 /**
  * Load a RESET request into the request queue.
@@ -259,7 +248,7 @@ SEABOLT_EXPORT int BoltConnection_load_pull_request(BoltConnection* connection, 
  * @param connection
  * @return
  */
-SEABOLT_EXPORT int BoltConnection_load_reset_request(BoltConnection* connection);
+SEABOLT_EXPORT int32_t BoltConnection_load_reset_request(BoltConnection* connection);
 
 /**
  * Obtain a handle to the last request sent to the server. This handle
@@ -270,9 +259,9 @@ SEABOLT_EXPORT int BoltConnection_load_reset_request(BoltConnection* connection)
  */
 SEABOLT_EXPORT BoltRequest BoltConnection_last_request(BoltConnection* connection);
 
-SEABOLT_EXPORT char* BoltConnection_server(BoltConnection* connection);
+SEABOLT_EXPORT const char* BoltConnection_server(BoltConnection* connection);
 
-SEABOLT_EXPORT char* BoltConnection_id(BoltConnection* connection);
+SEABOLT_EXPORT const char* BoltConnection_id(BoltConnection* connection);
 
 SEABOLT_EXPORT const BoltAddress* BoltConnection_address(BoltConnection* connection);
 
@@ -290,7 +279,7 @@ SEABOLT_EXPORT const BoltAddress* BoltConnection_local_endpoint(BoltConnection* 
  * @param connection
  * @return
  */
-SEABOLT_EXPORT char* BoltConnection_last_bookmark(BoltConnection* connection);
+SEABOLT_EXPORT const char* BoltConnection_last_bookmark(BoltConnection* connection);
 
 
 /**
@@ -298,7 +287,7 @@ SEABOLT_EXPORT char* BoltConnection_last_bookmark(BoltConnection* connection);
 * @param connection
 * @return
 */
-SEABOLT_EXPORT int BoltConnection_summary_success(BoltConnection* connection);
+SEABOLT_EXPORT int32_t BoltConnection_summary_success(BoltConnection* connection);
 
 /**
  * Obtain the details of the latest server generated FAILURE message

--- a/src/seabolt/src/bolt/connector.c
+++ b/src/seabolt/src/bolt/connector.c
@@ -22,6 +22,7 @@
 #include "address-private.h"
 #include "config-private.h"
 #include "connector-private.h"
+#include "log-private.h"
 #include "direct-pool.h"
 #include "mem.h"
 #include "routing-pool.h"
@@ -45,6 +46,9 @@ BoltConnector_create(BoltAddress* address, BoltValue* auth_token, struct BoltCon
     connector->address = BoltAddress_create(address->host, address->port);
     connector->auth_token = BoltValue_duplicate(auth_token);
     connector->config = BoltConnector_apply_defaults(BoltConfig_clone(config));
+
+    BoltLog_info(connector->config->log, "[connector]: Version %s [%s]", SEABOLT_VERSION,
+            SEABOLT_VERSION_HASH);
 
     switch (connector->config->mode) {
     case BOLT_MODE_DIRECT:
@@ -78,7 +82,7 @@ void BoltConnector_destroy(BoltConnector* connector)
     BoltMem_deallocate(connector, sizeof(BoltConnector));
 }
 
-BoltConnection* BoltConnector_acquire(BoltConnector* connector, BoltAccessMode mode, BoltStatus *status)
+BoltConnection* BoltConnector_acquire(BoltConnector* connector, BoltAccessMode mode, BoltStatus* status)
 {
     switch (connector->config->mode) {
     case BOLT_MODE_DIRECT:

--- a/src/seabolt/src/bolt/connector.h
+++ b/src/seabolt/src/bolt/connector.h
@@ -28,13 +28,6 @@ typedef int BoltAccessMode;
 #define BOLT_ACCESS_MODE_WRITE  0
 #define BOLT_ACCESS_MODE_READ   1
 
-struct BoltConnectionResult {
-    BoltConnection* connection;
-    BoltConnectionState connection_status;
-    int connection_error;
-    char* connection_error_ctx;
-};
-
 typedef struct BoltConnector BoltConnector;
 
 SEABOLT_EXPORT BoltConnector*
@@ -42,7 +35,7 @@ BoltConnector_create(struct BoltAddress* address, struct BoltValue* auth_token, 
 
 SEABOLT_EXPORT void BoltConnector_destroy(BoltConnector* connector);
 
-SEABOLT_EXPORT struct BoltConnectionResult BoltConnector_acquire(BoltConnector* connector, BoltAccessMode mode);
+SEABOLT_EXPORT BoltConnection* BoltConnector_acquire(BoltConnector* connector, BoltAccessMode mode, BoltStatus *status);
 
 SEABOLT_EXPORT void BoltConnector_release(BoltConnector* connector, struct BoltConnection* connection);
 

--- a/src/seabolt/src/bolt/direct-pool.h
+++ b/src/seabolt/src/bolt/direct-pool.h
@@ -49,8 +49,7 @@ BoltDirectPool_create(const struct BoltAddress* address, const struct BoltValue*
 
 void BoltDirectPool_destroy(struct BoltDirectPool* pool);
 
-struct BoltConnectionResult
-BoltDirectPool_acquire(struct BoltDirectPool* pool);
+BoltConnection* BoltDirectPool_acquire(struct BoltDirectPool* pool, BoltStatus* status);
 
 int BoltDirectPool_release(struct BoltDirectPool* pool, struct BoltConnection* connection);
 

--- a/src/seabolt/src/bolt/error.c
+++ b/src/seabolt/src/bolt/error.c
@@ -19,7 +19,7 @@
 
 #include "bolt-private.h"
 
-const char* BoltError_get_string(int code)
+const char* BoltError_get_string(int32_t code)
 {
     switch (code) {
     case BOLT_SUCCESS:

--- a/src/seabolt/src/bolt/error.h
+++ b/src/seabolt/src/bolt/error.h
@@ -54,6 +54,6 @@
 #define BOLT_CONNECTION_HAS_MORE_INFO   0xFFE
 #define BOLT_STATUS_SET   0xFFF
 
-SEABOLT_EXPORT const char* BoltError_get_string(int code);
+SEABOLT_EXPORT const char* BoltError_get_string(int32_t code);
 
 #endif //SEABOLT_ALL_ERROR_H

--- a/src/seabolt/src/bolt/log-private.h
+++ b/src/seabolt/src/bolt/log-private.h
@@ -22,7 +22,7 @@
 #include "log.h"
 
 struct BoltLog {
-    int state;
+    void* state;
 
     int error_enabled;
     int warning_enabled;

--- a/src/seabolt/src/bolt/log.c
+++ b/src/seabolt/src/bolt/log.c
@@ -24,7 +24,7 @@
 #include "string-builder.h"
 #include "values-private.h"
 
-struct BoltLog* BoltLog_create(int state)
+struct BoltLog* BoltLog_create(void* state)
 {
     struct BoltLog* log = (struct BoltLog*) BoltMem_allocate(sizeof(struct BoltLog));
     log->state = state;
@@ -86,16 +86,14 @@ void BoltLog_set_debug_func(BoltLog* log, log_func func)
     log->debug_logger = func;
 }
 
-void _perform_log_call(log_func func, int state, const char* format, va_list args)
+void _perform_log_call(log_func func, void* state, const char* format, va_list args)
 {
-    size_t
-            size = 512*sizeof(char);
+    uint64_t size = 512*sizeof(char);
     char* message_fmt = (char*) BoltMem_allocate(size);
     while (1) {
         va_list args_copy;
         va_copy(args_copy, args);
-        size_t
-                written = vsnprintf(message_fmt, size, format, args_copy);
+        uint64_t written = (uint64_t) vsnprintf(message_fmt, size, format, args_copy);
         va_end(args_copy);
         if (written<size) {
             break;

--- a/src/seabolt/src/bolt/log.h
+++ b/src/seabolt/src/bolt/log.h
@@ -25,11 +25,11 @@
 #include "connection.h"
 #include "values.h"
 
-typedef void (* log_func)(int state, const char* message);
+typedef void (* log_func)(void* state, const char* message);
 
 typedef struct BoltLog BoltLog;
 
-SEABOLT_EXPORT struct BoltLog* BoltLog_create(int state);
+SEABOLT_EXPORT struct BoltLog* BoltLog_create(void* state);
 
 SEABOLT_EXPORT void BoltLog_destroy(struct BoltLog* log);
 

--- a/src/seabolt/src/bolt/mem.c
+++ b/src/seabolt/src/bolt/mem.c
@@ -39,8 +39,8 @@ static int64_t __allocation_events = 0;
 void* BoltMem_allocate(int64_t new_size)
 {
     void* p = malloc(new_size);
-    size_t new_allocation = BoltUtil_add(&__allocation, new_size);
-    size_t peak_allocation = BoltUtil_add(&__peak_allocation, 0);
+    int64_t new_allocation = BoltUtil_add(&__allocation, new_size);
+    int64_t peak_allocation = BoltUtil_add(&__peak_allocation, 0);
     if (new_allocation>peak_allocation) BoltUtil_add(&__peak_allocation, new_allocation-peak_allocation);
     BoltUtil_increment(&__allocation_events);
     return p;
@@ -50,8 +50,8 @@ void* BoltMem_reallocate(void* ptr, int64_t old_size, int64_t new_size)
 {
     void* p = realloc(ptr, new_size);
 
-    size_t new_allocation = BoltUtil_add(&__allocation, -old_size+new_size);
-    size_t peak_allocation = BoltUtil_add(&__peak_allocation, 0);
+    int64_t new_allocation = BoltUtil_add(&__allocation, -old_size+new_size);
+    int64_t peak_allocation = BoltUtil_add(&__peak_allocation, 0);
     if (__allocation>__peak_allocation) BoltUtil_add(&__peak_allocation, new_allocation-peak_allocation);
     BoltUtil_increment(&__allocation_events);
     return p;

--- a/src/seabolt/src/bolt/routing-pool.c
+++ b/src/seabolt/src/bolt/routing-pool.c
@@ -479,60 +479,56 @@ void BoltRoutingPool_destroy(struct BoltRoutingPool* pool)
     BoltMem_deallocate(pool, SIZE_OF_ROUTING_POOL);
 }
 
-struct BoltConnectionResult
-BoltRoutingPool_acquire(struct BoltRoutingPool* pool, BoltAccessMode mode)
+BoltConnection* BoltRoutingPool_acquire(struct BoltRoutingPool* pool, BoltAccessMode mode, BoltStatus* status)
 {
     struct BoltAddress* server = NULL;
 
     BoltUtil_rwlock_rdlock(&pool->rwlock);
 
-    int status = BoltRoutingPool_ensure_routing_table(pool, mode);
-    if (status==BOLT_SUCCESS) {
+    int result = BoltRoutingPool_ensure_routing_table(pool, mode);
+    if (result==BOLT_SUCCESS) {
         server = mode==BOLT_ACCESS_MODE_READ
                  ? BoltRoutingPool_select_least_connected_reader(pool)
                  : BoltRoutingPool_select_least_connected_writer(pool);
         if (server==NULL) {
-            status = BOLT_ROUTING_NO_SERVERS_TO_SELECT;
+            result = BOLT_ROUTING_NO_SERVERS_TO_SELECT;
         }
     }
 
     int server_pool_index = -1;
-    if (status==BOLT_SUCCESS) {
+    if (result==BOLT_SUCCESS) {
         server_pool_index = BoltRoutingPool_ensure_server(pool, server);
         if (server_pool_index<0) {
-            status = BOLT_ROUTING_UNABLE_TO_CONSTRUCT_POOL_FOR_SERVER;
+            result = BOLT_ROUTING_UNABLE_TO_CONSTRUCT_POOL_FOR_SERVER;
         }
     }
 
-    struct BoltConnectionResult result = {NULL, BOLT_CONNECTION_STATE_DISCONNECTED, BOLT_SUCCESS, NULL};
-    if (status==BOLT_SUCCESS) {
-        result = BoltDirectPool_acquire(pool->server_pools[server_pool_index]);
-        if (result.connection!=NULL) {
-            status = BOLT_SUCCESS;
-            result.connection->on_error_cb_state = pool;
-            result.connection->on_error_cb = BoltRoutingPool_connection_error_handler;
-        }
-        else {
-            status = result.connection_error;
+    BoltConnection* connection = NULL;
+    if (result==BOLT_SUCCESS) {
+        connection = BoltDirectPool_acquire(pool->server_pools[server_pool_index], status);
+        if (connection!=NULL) {
+            result = BOLT_SUCCESS;
+            connection->on_error_cb_state = pool;
+            connection->on_error_cb = BoltRoutingPool_connection_error_handler;
         }
     }
 
     BoltUtil_rwlock_rdunlock(&pool->rwlock);
 
-    if (status==BOLT_SUCCESS) {
-        return result;
+    if (result==BOLT_SUCCESS) {
+        return connection;
     }
 
     // check if we were able to complete server selection. this is not the case when routing
     // table refresh fails.
     if (server!=NULL) {
-        BoltRoutingPool_handle_connection_error_by_code(pool, server, status);
+        BoltRoutingPool_handle_connection_error_by_code(pool, server, result);
     }
 
-    result.connection_error = status;
-    result.connection_error_ctx = NULL;
+    status->error = result;
+    status->error_ctx = NULL;
 
-    return result;
+    return NULL;
 }
 
 int BoltRoutingPool_release(struct BoltRoutingPool* pool, struct BoltConnection* connection)

--- a/src/seabolt/src/bolt/routing-pool.c
+++ b/src/seabolt/src/bolt/routing-pool.c
@@ -19,6 +19,7 @@
 
 #include "bolt-private.h"
 #include "address-private.h"
+#include "address-resolver-private.h"
 #include "address-set-private.h"
 #include "config-private.h"
 #include "connection-private.h"

--- a/src/seabolt/src/bolt/routing-pool.h
+++ b/src/seabolt/src/bolt/routing-pool.h
@@ -43,12 +43,12 @@ struct BoltRoutingPool {
 #define SIZE_OF_ROUTING_POOL_PTR sizeof(struct BoltRoutingConnectionPool*)
 
 struct BoltRoutingPool*
-BoltRoutingPool_create(struct BoltAddress* address, const struct BoltValue* auth_token, const struct BoltConfig* config);
+BoltRoutingPool_create(struct BoltAddress* address, const struct BoltValue* auth_token,
+        const struct BoltConfig* config);
 
 void BoltRoutingPool_destroy(struct BoltRoutingPool* pool);
 
-struct BoltConnectionResult
-BoltRoutingPool_acquire(struct BoltRoutingPool* pool, BoltAccessMode mode);
+BoltConnection* BoltRoutingPool_acquire(struct BoltRoutingPool* pool, BoltAccessMode mode, BoltStatus* status);
 
 int BoltRoutingPool_release(struct BoltRoutingPool* pool, struct BoltConnection* connection);
 

--- a/src/seabolt/src/bolt/stats.c
+++ b/src/seabolt/src/bolt/stats.c
@@ -21,12 +21,12 @@
 #include "stats.h"
 #include "mem.h"
 
-size_t BoltStat_memory_allocation_current()
+uint64_t BoltStat_memory_allocation_current()
 {
     return BoltMem_current_allocation();
 }
 
-size_t BoltStat_memory_allocation_peak()
+uint64_t BoltStat_memory_allocation_peak()
 {
     return BoltMem_peak_allocation();
 }

--- a/src/seabolt/src/bolt/stats.h
+++ b/src/seabolt/src/bolt/stats.h
@@ -21,9 +21,9 @@
 
 #include "bolt-public.h"
 
-SEABOLT_EXPORT size_t BoltStat_memory_allocation_current();
+SEABOLT_EXPORT uint64_t BoltStat_memory_allocation_current();
 
-SEABOLT_EXPORT size_t BoltStat_memory_allocation_peak();
+SEABOLT_EXPORT uint64_t BoltStat_memory_allocation_peak();
 
 SEABOLT_EXPORT int64_t BoltStat_memory_allocation_events();
 

--- a/src/seabolt/src/bolt/status-private.h
+++ b/src/seabolt/src/bolt/status-private.h
@@ -28,8 +28,6 @@ struct BoltStatus {
     uint64_t error_ctx_size;
 };
 
-BoltStatus* BoltStatus_create(uint64_t context_size);
-
-void BoltStatus_destroy(BoltStatus* status);
+BoltStatus* BoltStatus_create_with_ctx(uint64_t ctx_size);
 
 #endif //SEABOLT_STATUS_PRIVATE_H

--- a/src/seabolt/src/bolt/status-private.h
+++ b/src/seabolt/src/bolt/status-private.h
@@ -23,12 +23,12 @@
 
 struct BoltStatus {
     BoltConnectionState state;
-    int error;
+    int32_t error;
     char* error_ctx;
-    size_t error_ctx_size;
+    uint64_t error_ctx_size;
 };
 
-BoltStatus* BoltStatus_create(size_t context_size);
+BoltStatus* BoltStatus_create(uint64_t context_size);
 
 void BoltStatus_destroy(BoltStatus* status);
 

--- a/src/seabolt/src/bolt/status.c
+++ b/src/seabolt/src/bolt/status.c
@@ -21,19 +21,24 @@
 #include "status-private.h"
 #include "mem.h"
 
-BoltStatus* BoltStatus_create(uint64_t context_size)
+BoltStatus* BoltStatus_create()
+{
+    return BoltStatus_create_with_ctx(0);
+}
+
+BoltStatus* BoltStatus_create_with_ctx(uint64_t context_size)
 {
     BoltStatus* status = BoltMem_allocate(sizeof(BoltStatus));
     status->state = BOLT_CONNECTION_STATE_DISCONNECTED;
     status->error = BOLT_SUCCESS;
-    status->error_ctx = BoltMem_allocate(context_size);
+    status->error_ctx = context_size ? BoltMem_allocate(context_size) : NULL;
     status->error_ctx_size = context_size;
     return status;
 }
 
 void BoltStatus_destroy(BoltStatus* status)
 {
-    if (status->error_ctx!=NULL) {
+    if (status->error_ctx_size>0) {
         BoltMem_deallocate(status->error_ctx, status->error_ctx_size);
     }
     BoltMem_deallocate(status, sizeof(BoltStatus));

--- a/src/seabolt/src/bolt/status.c
+++ b/src/seabolt/src/bolt/status.c
@@ -21,7 +21,7 @@
 #include "status-private.h"
 #include "mem.h"
 
-BoltStatus* BoltStatus_create(size_t context_size)
+BoltStatus* BoltStatus_create(uint64_t context_size)
 {
     BoltStatus* status = BoltMem_allocate(sizeof(BoltStatus));
     status->state = BOLT_CONNECTION_STATE_DISCONNECTED;
@@ -44,7 +44,7 @@ BoltConnectionState BoltStatus_get_state(BoltStatus* status)
     return status->state;
 }
 
-int BoltStatus_get_error(BoltStatus* status)
+int32_t BoltStatus_get_error(BoltStatus* status)
 {
     return status->error;
 }

--- a/src/seabolt/src/bolt/status.h
+++ b/src/seabolt/src/bolt/status.h
@@ -38,6 +38,10 @@ typedef int BoltConnectionState;
  */
 typedef struct BoltStatus BoltStatus;
 
+SEABOLT_EXPORT BoltStatus* BoltStatus_create();
+
+SEABOLT_EXPORT void BoltStatus_destroy(BoltStatus* status);
+
 SEABOLT_EXPORT BoltConnectionState BoltStatus_get_state(BoltStatus* status);
 
 SEABOLT_EXPORT int32_t BoltStatus_get_error(BoltStatus* status);

--- a/src/seabolt/src/bolt/status.h
+++ b/src/seabolt/src/bolt/status.h
@@ -40,7 +40,7 @@ typedef struct BoltStatus BoltStatus;
 
 SEABOLT_EXPORT BoltConnectionState BoltStatus_get_state(BoltStatus* status);
 
-SEABOLT_EXPORT int BoltStatus_get_error(BoltStatus* status);
+SEABOLT_EXPORT int32_t BoltStatus_get_error(BoltStatus* status);
 
 SEABOLT_EXPORT const char* BoltStatus_get_error_context(BoltStatus* status);
 

--- a/src/seabolt/src/bolt/tls.c
+++ b/src/seabolt/src/bolt/tls.c
@@ -106,7 +106,7 @@ SSL_CTX* create_ssl_ctx(struct BoltTrust* trust, const char* hostname, const str
             if (trust->certs!=NULL && trust->certs_len!=0) {
                 // load the buffer into a BIO memory reader
                 BIO* trusted_certs_bio = BIO_new(BIO_s_mem());
-                BIO_write(trusted_certs_bio, trust->certs, trust->certs_len);
+                BIO_write(trusted_certs_bio, trust->certs, (int32_t)trust->certs_len);
 
                 // read all X509_AUX objects encoded (_AUX suffix tells that these
                 // certificates are to be treated as trusted

--- a/src/seabolt/src/bolt/v1.c
+++ b/src/seabolt/src/bolt/v1.c
@@ -163,8 +163,8 @@ void ensure_failure_data(struct BoltProtocolV1State* state)
     if (state->failure_data==NULL) {
         state->failure_data = BoltValue_create();
         BoltValue_format_as_Dictionary(state->failure_data, 2);
-        BoltDictionary_set_key(state->failure_data, 0, "code", strlen("code"));
-        BoltDictionary_set_key(state->failure_data, 1, "message", strlen("message"));
+        BoltDictionary_set_key(state->failure_data, 0, "code", (int32_t)strlen("code"));
+        BoltDictionary_set_key(state->failure_data, 1, "message", (int32_t)strlen("message"));
     }
 }
 
@@ -276,7 +276,7 @@ struct BoltValue* BoltProtocolV1_set_run_cypher_parameter(struct BoltConnection*
 {
     struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
     struct BoltValue* params = BoltMessage_param(state->run_request, 1);
-    BoltDictionary_set_key(params, index, name, name_size);
+    BoltDictionary_set_key(params, index, name, (int32_t)name_size);
     return BoltDictionary_value(params, index);
 }
 

--- a/src/seabolt/src/bolt/v3.c
+++ b/src/seabolt/src/bolt/v3.c
@@ -884,7 +884,7 @@ void BoltProtocolV3_extract_metadata(struct BoltConnection* connection, struct B
                 case BOLT_STRING: {
                     char new_connection_id[MAX_CONNECTION_ID_SIZE];
                     strncpy(new_connection_id, BoltString_get(value), (size_t) value->size+1);
-                    char* old_connection_id = BoltConnection_id(connection);
+                    const char* old_connection_id = BoltConnection_id(connection);
                     snprintf(state->connection_id, MAX_CONNECTION_ID_SIZE, "%s, %s", old_connection_id,
                             new_connection_id);
                     BoltLog_info(connection->log, "[%s]: <SET connection_id=\"%s\">", old_connection_id,

--- a/src/seabolt/src/bolt/v3.c
+++ b/src/seabolt/src/bolt/v3.c
@@ -633,7 +633,7 @@ BoltProtocolV3_set_run_cypher_parameter(struct BoltConnection* connection, int32
 {
     struct BoltProtocolV3State* state = BoltProtocolV3_state(connection);
     struct BoltValue* params = BoltMessage_param(state->run_request, 1);
-    BoltDictionary_set_key(params, index, name, name_size);
+    BoltDictionary_set_key(params, index, name, (int32_t)name_size);
     return BoltDictionary_value(params, index);
 }
 

--- a/src/seabolt/src/bolt/values-private.h
+++ b/src/seabolt/src/bolt/values-private.h
@@ -58,10 +58,6 @@ struct BoltValue {
     int16_t subtype;
 
     /// Logical size of this value.
-    /// For portability between platforms, the logical
-    /// size of a value (e.g. string length or list size)
-    /// cannot exceed 2^31, therefore an int32_t is safe
-    /// here.
     int32_t size;
 
     /// Physical size of this value, in bytes.

--- a/src/seabolt/src/bolt/values.c
+++ b/src/seabolt/src/bolt/values.c
@@ -286,7 +286,7 @@ enum BoltType BoltValue_type(const struct BoltValue* value)
     return (enum BoltType) (value->type);
 }
 
-int32_t BoltValue_string(const struct BoltValue* value, char* dest, int32_t length, struct BoltConnection* connection)
+int32_t BoltValue_to_string(const struct BoltValue* value, char* dest, int32_t length, struct BoltConnection* connection)
 {
     name_resolver_func name_resolver = NULL;
     struct StringBuilder* builder = StringBuilder_create();
@@ -435,7 +435,7 @@ int32_t BoltDictionary_get_key_size(const struct BoltValue* value, int32_t index
 }
 
 int32_t
-BoltDictionary_get_key_index(const struct BoltValue* value, const char* key, size_t key_size, int32_t start_index)
+BoltDictionary_get_key_index(const struct BoltValue* value, const char* key, int32_t key_size, int32_t start_index)
 {
     assert(BoltValue_type(value)==BOLT_DICTIONARY);
     if (start_index>=value->size) return -1;
@@ -450,7 +450,7 @@ BoltDictionary_get_key_index(const struct BoltValue* value, const char* key, siz
     return -1;
 }
 
-int BoltDictionary_set_key(struct BoltValue* value, int32_t index, const char* key, size_t key_size)
+int32_t BoltDictionary_set_key(struct BoltValue* value, int32_t index, const char* key, int32_t key_size)
 {
     if (key_size<=INT32_MAX) {
         assert(BoltValue_type(value)==BOLT_DICTIONARY);
@@ -468,7 +468,7 @@ struct BoltValue* BoltDictionary_value(const struct BoltValue* value, int32_t in
     return &value->data.extended.as_value[2*index+1];
 }
 
-struct BoltValue* BoltDictionary_value_by_key(const struct BoltValue* value, const char* key, size_t key_size)
+struct BoltValue* BoltDictionary_value_by_key(const struct BoltValue* value, const char* key, int32_t key_size)
 {
     const int32_t index = BoltDictionary_get_key_index(value, key, key_size, 0);
     if (index<0) {

--- a/src/seabolt/src/bolt/values.h
+++ b/src/seabolt/src/bolt/values.h
@@ -114,7 +114,7 @@ SEABOLT_EXPORT int32_t BoltValue_size(const struct BoltValue* value);
  */
 SEABOLT_EXPORT enum BoltType BoltValue_type(const struct BoltValue* value);
 
-SEABOLT_EXPORT int32_t BoltValue_string(const struct BoltValue* value, char *dest, int32_t length, struct BoltConnection* connection);
+SEABOLT_EXPORT int32_t BoltValue_to_string(const struct BoltValue* value, char *dest, int32_t length, struct BoltConnection* connection);
 /**
  * Set a BoltValue instance to null.
  *
@@ -147,13 +147,13 @@ SEABOLT_EXPORT const char* BoltDictionary_get_key(const struct BoltValue* value,
 SEABOLT_EXPORT int32_t BoltDictionary_get_key_size(const struct BoltValue* value, int32_t index);
 
 SEABOLT_EXPORT int32_t
-BoltDictionary_get_key_index(const struct BoltValue* value, const char* key, size_t key_size, int32_t start_index);
+BoltDictionary_get_key_index(const struct BoltValue* value, const char* key, int32_t key_size, int32_t start_index);
 
-SEABOLT_EXPORT int BoltDictionary_set_key(struct BoltValue* value, int32_t index, const char* key, size_t key_size);
+SEABOLT_EXPORT int32_t BoltDictionary_set_key(struct BoltValue* value, int32_t index, const char* key, int32_t key_size);
 
 SEABOLT_EXPORT struct BoltValue* BoltDictionary_value(const struct BoltValue* value, int32_t index);
 
-SEABOLT_EXPORT struct BoltValue* BoltDictionary_value_by_key(const struct BoltValue* value, const char* key, size_t key_size);
+SEABOLT_EXPORT struct BoltValue* BoltDictionary_value_by_key(const struct BoltValue* value, const char* key, int32_t key_size);
 
 /**
  * Format a BoltValue instance to hold a list.

--- a/src/seabolt/tests/test-direct.cpp
+++ b/src/seabolt/tests/test-direct.cpp
@@ -400,8 +400,8 @@ SCENARIO("Test FAILURE", "[integration][ipv6][secure]")
                 auto failure_data = BoltConnection_failure(connection);
                 REQUIRE(failure_data!=nullptr);
 
-                struct BoltValue* code = BoltDictionary_value_by_key(failure_data, "code", strlen("code"));
-                struct BoltValue* message = BoltDictionary_value_by_key(failure_data, "message", strlen("message"));
+                struct BoltValue* code = BoltDictionary_value_by_key(failure_data, "code", (int32_t)strlen("code"));
+                struct BoltValue* message = BoltDictionary_value_by_key(failure_data, "message", (int32_t)strlen("message"));
                 REQUIRE(code!=nullptr);
                 REQUIRE(BoltValue_type(code)==BOLT_STRING);
                 REQUIRE(BoltString_equals(code, "Neo.ClientError.Statement.SyntaxError",
@@ -421,8 +421,8 @@ SCENARIO("Test FAILURE", "[integration][ipv6][secure]")
                 struct BoltValue* failure_data = BoltConnection_failure(connection);
                 REQUIRE(failure_data!=nullptr);
 
-                struct BoltValue* code = BoltDictionary_value_by_key(failure_data, "code", strlen("code"));
-                struct BoltValue* message = BoltDictionary_value_by_key(failure_data, "message", strlen("message"));
+                struct BoltValue* code = BoltDictionary_value_by_key(failure_data, "code", (int32_t)strlen("code"));
+                struct BoltValue* message = BoltDictionary_value_by_key(failure_data, "message", (int32_t)strlen("message"));
                 REQUIRE(code!=nullptr);
                 REQUIRE(BoltValue_type(code)==BOLT_STRING);
                 REQUIRE(BoltString_equals(code, "Neo.ClientError.Statement.SyntaxError",
@@ -448,8 +448,8 @@ SCENARIO("Test FAILURE", "[integration][ipv6][secure]")
                 auto failure_data = BoltConnection_failure(connection);
                 REQUIRE(failure_data!=nullptr);
 
-                struct BoltValue* code = BoltDictionary_value_by_key(failure_data, "code", strlen("code"));
-                struct BoltValue* message = BoltDictionary_value_by_key(failure_data, "message", strlen("message"));
+                struct BoltValue* code = BoltDictionary_value_by_key(failure_data, "code", (int32_t)strlen("code"));
+                struct BoltValue* message = BoltDictionary_value_by_key(failure_data, "message", (int32_t)strlen("message"));
                 REQUIRE(code!=nullptr);
                 REQUIRE(BoltValue_type(code)==BOLT_STRING);
                 REQUIRE(BoltString_equals(code, "Neo.ClientError.Statement.SyntaxError",


### PR DESCRIPTION
This PR reviews parameters in public functions and makes use of explicitly sized integral types (`int32_t`, `int64_t`, `uint64_t`, etc) wherever possible.

It also communicates connection acquisition errors back to the requestor by means of `BoltStatus` type removing the previously used `BoltConnectionResult`. 