### PR TITLE
Ignore SIGPIPE signal on POSIX environments

### DIFF
--- a/src/seabolt/src/bolt/bolt-private.h
+++ b/src/seabolt/src/bolt/bolt-private.h
@@ -32,6 +32,7 @@
 #include <netinet/tcp.h>
 #include <fcntl.h>
 #include <netdb.h>
+#include <signal.h>
 
 #endif // USE_POSIXSOCK
 

--- a/src/seabolt/src/bolt/connection.c
+++ b/src/seabolt/src/bolt/connection.c
@@ -577,7 +577,9 @@ int _send(BoltConnection* connection, const char* data, int size)
 
 #if USE_POSIXSOCK && !defined(SO_NOSIGPIPE)
     struct sigaction ignore_act, previous_act;
+#if defined(MSG_NOSIGNAL)
     if (connection->transport==BOLT_TRANSPORT_ENCRYPTED) {
+#endif
         memset(&ignore_act, '\0', sizeof(ignore_act));
         memset(&previous_act, '\0', sizeof(previous_act));
         ignore_act.sa_handler = SIG_IGN;
@@ -589,7 +591,9 @@ int _send(BoltConnection* connection, const char* data, int size)
                     last_error);
             return BOLT_STATUS_SET;
         }
+#if defined(MSG_NOSIGNAL)
     }
+#endif
 #endif
     int status = BOLT_SUCCESS;
     int remaining = size;
@@ -642,7 +646,9 @@ int _send(BoltConnection* connection, const char* data, int size)
         BoltLog_info(connection->log, "[%s]: (Sent %d of %d bytes)", BoltConnection_id(connection), total_sent, size);
     }
 #if USE_POSIXSOCK && !defined(SO_NOSIGPIPE)
+#if defined(MSG_NOSIGNAL)
     if (connection->transport==BOLT_TRANSPORT_ENCRYPTED) {
+#endif
         if (sigaction(SIGPIPE, &previous_act, NULL)<0) {
             int last_error = _last_error_code();
             _set_status_with_ctx(connection, BOLT_CONNECTION_STATE_DEFUNCT, _transform_error(last_error),
@@ -650,7 +656,9 @@ int _send(BoltConnection* connection, const char* data, int size)
                     last_error);
             return BOLT_STATUS_SET;
         }
+#if defined(MSG_NOSIGNAL)
     }
+#endif
 #endif
     return status;
 }
@@ -672,7 +680,9 @@ int _receive(BoltConnection* connection, char* buffer, int min_size, int max_siz
 
 #if USE_POSIXSOCK && !defined(SO_NOSIGPIPE)
     struct sigaction ignore_act, previous_act;
+#if defined(MSG_NOSIGNAL)
     if (connection->transport==BOLT_TRANSPORT_ENCRYPTED) {
+#endif
         memset(&ignore_act, '\0', sizeof(ignore_act));
         memset(&previous_act, '\0', sizeof(previous_act));
         ignore_act.sa_handler = SIG_IGN;
@@ -684,7 +694,9 @@ int _receive(BoltConnection* connection, char* buffer, int min_size, int max_siz
                     last_error);
             return BOLT_STATUS_SET;
         }
+#if defined(MSG_NOSIGNAL)
     }
+#endif
 #endif
 
     int status = BOLT_SUCCESS;
@@ -724,7 +736,8 @@ int _receive(BoltConnection* connection, char* buffer, int min_size, int max_siz
             }
             case BOLT_TRANSPORT_ENCRYPTED: {
                 int last_error = 0, ssl_error = 0;
-                int last_error_transformed = _last_error_code_ssl(connection, single_received, &ssl_error, &last_error);
+                int last_error_transformed = _last_error_code_ssl(connection, single_received, &ssl_error,
+                        &last_error);
                 _set_status_with_ctx(connection, BOLT_CONNECTION_STATE_DEFUNCT, last_error_transformed,
                         "_receive(%s:%d), receive_s error code: %d, underlying error code: %d", __FILE__, __LINE__,
                         ssl_error, last_error);
@@ -750,7 +763,9 @@ int _receive(BoltConnection* connection, char* buffer, int min_size, int max_siz
     }
     *received = total_received;
 #if USE_POSIXSOCK && !defined(SO_NOSIGPIPE)
+#if defined(MSG_NOSIGNAL)
     if (connection->transport==BOLT_TRANSPORT_ENCRYPTED) {
+#endif
         if (sigaction(SIGPIPE, &previous_act, NULL)<0) {
             int last_error = _last_error_code();
             _set_status_with_ctx(connection, BOLT_CONNECTION_STATE_DEFUNCT, _transform_error(last_error),
@@ -758,7 +773,9 @@ int _receive(BoltConnection* connection, char* buffer, int min_size, int max_siz
                     last_error);
             return BOLT_STATUS_SET;
         }
+#if defined(MSG_NOSIGNAL)
     }
+#endif
 #endif
     return status;
 }

--- a/src/seabolt/src/bolt/tls.c
+++ b/src/seabolt/src/bolt/tls.c
@@ -112,6 +112,7 @@ SSL_CTX* create_ssl_ctx(struct BoltTrust* trust, const char* hostname, const str
                 // certificates are to be treated as trusted
                 X509* trusted_cert = PEM_read_bio_X509_AUX(trusted_certs_bio, NULL, NULL, NULL);
                 while (trusted_cert!=NULL) {
+                    BoltLog_debug(log, "adding trusted certificate");
                     X509_STORE_add_cert(store, trusted_cert);
 
                     trusted_cert = PEM_read_bio_X509_AUX(trusted_certs_bio, NULL, NULL, NULL);

--- a/src/seabolt/src/bolt/tls.c
+++ b/src/seabolt/src/bolt/tls.c
@@ -112,7 +112,6 @@ SSL_CTX* create_ssl_ctx(struct BoltTrust* trust, const char* hostname, const str
                 // certificates are to be treated as trusted
                 X509* trusted_cert = PEM_read_bio_X509_AUX(trusted_certs_bio, NULL, NULL, NULL);
                 while (trusted_cert!=NULL) {
-                    BoltLog_debug(log, "adding trusted certificate");
                     X509_STORE_add_cert(store, trusted_cert);
 
                     trusted_cert = PEM_read_bio_X509_AUX(trusted_certs_bio, NULL, NULL, NULL);


### PR DESCRIPTION
On POSIX systems, a SIGPIPE signal can be generated if the peer on a stream-oriented socket  has  closed the connection. Some systems provide `SO_NOSIGPIPE` socket option that can be set as a socket option and some has `MSG_NOSIGNAL` flag that can be specified on `send` and `recv` calls.

The problems becomes more serious when using an encrypted connection (with OpenSSL) where there's no control on flags specified on `send` and `recv` calls. And since close operation with encrypted connections may result in additional `send`/`receive` calls, it is more probable to receive a SIGPIPE signal that can halt the process if there isn't any handler installed.

This PR makes the following changes regarding signal handling;

1. Set `SO_NOSIGPIPE` socket option on systems where it is available. Since this is a socket level option, no more signal handling is carried out elsewhere.
2. Add `MSG_NOSIGNAL` option to `send` and `recv` calls where it is available.
3. BoltConnection internal `_send`, `_receive` and `_close` functions now include a `sigaction` call to ignore SIGPIPE signals and reverts to the previous handler on return. This is only carried out if using encrypted connections or `MSG_NOSIGNAL` is not defined.