### PR TITLE
Support for gcc: fix for format-truncation error

### DIFF
--- a/src/seabolt/src/bolt/v3.h
+++ b/src/seabolt/src/bolt/v3.h
@@ -50,6 +50,9 @@
 #define BOLT_V3_ZONED_DATE_TIME     'f'
 #define BOLT_V3_DURATION            'E'
 
+
+void BoltProtocolV3_extract_metadata(struct BoltConnection* connection, struct BoltValue* metadata);
+
 struct BoltProtocol* BoltProtocolV3_create_protocol();
 
 void BoltProtocolV3_destroy_protocol(struct BoltProtocol* protocol);

--- a/src/seabolt/tests/CMakeLists.txt
+++ b/src/seabolt/tests/CMakeLists.txt
@@ -10,7 +10,8 @@ target_sources(seabolt-test
         ${CMAKE_CURRENT_LIST_DIR}/test-values.cpp
         ${CMAKE_CURRENT_LIST_DIR}/test-warden.cpp
         ${CMAKE_CURRENT_LIST_DIR}/test-string-builder.cpp
-        ${CMAKE_CURRENT_LIST_DIR}/test-direct-pool.cpp)
+        ${CMAKE_CURRENT_LIST_DIR}/test-direct-pool.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/test-v3.cpp)
 
 target_include_directories(seabolt-test
         PRIVATE

--- a/src/seabolt/tests/integration.hpp
+++ b/src/seabolt/tests/integration.hpp
@@ -34,6 +34,7 @@ extern "C"
 #include "bolt/values-private.h"
 #include "bolt/string-builder.h"
 #include "bolt/direct-pool.h"
+#include "bolt/v3.h"
 }
 
 #define SETTING(name, default_value) ((char*)((getenv(name) == nullptr) ? (default_value) : getenv(name)))

--- a/src/seabolt/tests/test-v3.cpp
+++ b/src/seabolt/tests/test-v3.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <string>
+#include "integration.hpp"
+#include "catch.hpp"
+
+using Catch::Matchers::Equals;
+
+#define CONNECTION_ID_KEY "connection_id"
+#define CONNECTION_ID_KEY_SIZE 13
+
+TEST_CASE("Extract metadata", "[unit]") {
+    GIVEN("an open and initialised connection") {
+        struct BoltConnection* connection = bolt_open_init_default();
+        if (connection->protocol_version == 3) {
+            BoltValue* metadata = BoltValue_create();
+            BoltValue_format_as_Dictionary(metadata, 1);
+            BoltDictionary_set_key(metadata, 0, CONNECTION_ID_KEY, CONNECTION_ID_KEY_SIZE);
+
+            WHEN("new connection_id would not overrun buffer") {
+                std::string old_connection_id = BoltConnection_id(connection);
+
+                std::string value = "foo";
+                BoltValue_format_as_String(
+                    BoltDictionary_value(metadata, 0), value.c_str(), (int32_t) value.length());
+                BoltProtocolV3_extract_metadata(connection, metadata);
+
+                std::string connection_id = BoltConnection_id(connection);
+
+                REQUIRE(old_connection_id.length() > 0);
+                THEN("it should not be concatenated to a blank with comma") {
+                    REQUIRE_THAT(connection_id, Equals(
+                        old_connection_id + ", " + value
+                    ));
+                }
+            }
+            WHEN("new connection_id would overrun buffer") {
+                THEN("new connection_id should be ignored and the original connection_id should persist") {
+                    std::string old_connection_id = BoltConnection_id(connection);
+                    std::string value =
+                        "0123456789""0123456789""0123456789""0123456789""0123456789"
+                        "0123456789""0123456789""0123456789""0123456789""0123456789"
+                        "0123456789""0123456789""0123456789""0123456789""0123456789"
+                        "0123456789""0123456789""0123456789""0123456789""0123456789"
+                        ;
+                    BoltValue_format_as_String(BoltDictionary_value(metadata, 0), value.c_str(),
+                        (int32_t) value.length());
+                    BoltProtocolV3_extract_metadata(connection, metadata);
+
+                    std::string connection_id = BoltConnection_id(connection);
+
+                    REQUIRE(connection_id.find(value) == std::string::npos);
+                    REQUIRE(connection_id == old_connection_id);
+                }
+            }
+
+            BoltValue_destroy(metadata);
+        }
+        else {
+            WARN("Test is skipped because functionality is only available for Bolt V3.");
+        }
+        bolt_close_and_destroy_b(connection);
+    }
+}


### PR DESCRIPTION
I was able to build using GCC versions 6 and 7 and clang on my non-Debian platform (Arch Linux), but I ran into the following on GCC version 8:

```
/home/tjb1982/pojagi/them/seabolt/src/seabolt/src/bolt/v3.c: In function ‘BoltProtocolV3_extract_metadata’:
/home/tjb1982/pojagi/them/seabolt/src/seabolt/src/bolt/v3.c:888:81: error: ‘%s’ directive output may be truncated writing up to 199 bytes into a region of size 198 [-Werror=format-truncation=]
                     snprintf(state->connection_id, MAX_CONNECTION_ID_SIZE, "%s, %s", old_connection_id,
                                                                                 ^~
                             new_connection_id);
                             ~~~~~~~~~~~~~~~~~                                    
/home/tjb1982/pojagi/them/seabolt/src/seabolt/src/bolt/v3.c:888:21: note: ‘snprintf’ output 3 or more bytes (assuming 202) into a destination of size 200
                     snprintf(state->connection_id, MAX_CONNECTION_ID_SIZE, "%s, %s", old_connection_id,
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                             new_connection_id);
                             ~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[2]: *** [CMakeFiles/seabolt-shared.dir/build.make:388: CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/v3.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:73: CMakeFiles/seabolt-shared.dir/all] Error 2
make: *** [Makefile:163: all] Error 2

```

~It's possible to just disable this error check, but the change in this PR is pretty straightforward and does prevent truncating the `connection_id` in `snprintf` here, since it makes sense that the format string `"%s, %s"` could need to accommodate two full-length `connection_id`s and three additional chars for `' '` `','` and `\0`:~

~`state->connection_id` is a `char *` so the struct itself doesn't really care what the length of the string is: https://github.com/neo4j-drivers/seabolt/blob/1.7-dev/src/seabolt/src/bolt/v3.c#L80~

**edit** I take it back. `state->connection_id` is heap allocated to be `MAX_CONNECTION_ID_SIZE` so it would be a terrible idea to try to `snprintf` more than that length there. In that case, I think the first commit is wrong and the right solution to this involves a check to see that the `new_connection_id` added to the `old_connection_id` + `", "` (i.e., from the format string) won't overrun the buffer. If it's too long we log an error and break.