### PR TITLE
Addl tooling for docker CI for local-package-based regression testing

### DIFF
--- a/ci/linux.sh
+++ b/ci/linux.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 
+set -e
+
 BASE=$(dirname $0)
+
+if [ "x${NEOCTRL_LOCAL_PACKAGE}" != "x" ]; then
+    NLPPATH=/tmp/neo4j/${NEOCTRL_LOCAL_PACKAGE}
+    mkdir -p $(dirname $NLPPATH) && cp ${NEOCTRL_LOCAL_PACKAGE} ${NLPPATH}
+    NLPVOLUME="$(dirname $NLPPATH):/opt/neo4j"
+    NEOCTRL_LOCAL_PACKAGE="/opt/neo4j/$(basename $NLPPATH)"
+    DOCKER_RUN_ARGS="${DOCKER_RUN_ARGS} -v ${NLPVOLUME} --env NEOCTRL_LOCAL_PACKAGE=${NEOCTRL_LOCAL_PACKAGE}"
+fi
 
 docker image build -t seabolt-ci -f $BASE/linux/Dockerfile.build $BASE/..
 if [[ "$?" -ne "0" ]]; then
@@ -11,7 +21,7 @@ fi
 docker container run --rm --env TEAMCITY_HOST="$TEAMCITY_HOST" --env TEAMCITY_USER="$TEAMCITY_USER" \
     --env TEAMCITY_PASSWORD="$TEAMCITY_PASSWORD" --env NEOCTRLARGS="$NEOCTRLARGS" \
     --env BOLT_PORT="7687" --env HTTP_PORT="7474" --env HTTPS_PORT="7473" \
-    --env BOLT_PASSWORD="password" seabolt-ci
+    --env BOLT_PASSWORD="password" $DOCKER_RUN_ARGS seabolt-ci
 if [[ "$?" -ne "0" ]]; then
     echo "FATAL: docker container run failed, possible test failure."
     exit 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,53 @@
+version: '2.1'
+services:
+  neo4j-server:
+    image: neo4j:3.5.0
+    expose:
+    - &bolt-port 7687
+    - &http-port 7474
+    - &https-port 7473
+    ports:
+    - 7687:7687
+    - 7474:7474
+    environment:
+      NEO4J_AUTH: neo4j/password
+      NEO4J_dbms_connector_bolt_listen__address: ":7687"
+      NEO4J_dbms_connector_http_listen__address: ":7474"
+      NEO4J_dbms_connector_https_listen__address: ":7473"
+      NEO4J_dbms_connectors_default__listen__address: "::"
+    networks:
+      ci_net:
+        ipv6_address: &server-address 2001:3200:3200::20
+
+  seabolt-ci:
+    depends_on: [neo4j-server]
+    command: |
+      bash -c "
+         while ! /seabolt/build/bin/seabolt-cli debug -a \"UNWIND range(1, 10000) AS n RETURN n\";
+             do sleep 10;
+         done;
+         /seabolt/build/bin/seabolt-test && false || while true; do sleep 1; done
+      "
+    build:
+      context: .
+      dockerfile: ./ci/linux/Dockerfile.build
+    environment:
+      BOLT_PORT: *bolt-port
+      BOLT_USER: neo4j
+      BOLT_IPV4_HOST: neo4j-server
+      BOLT_IPV6_HOST: neo4j-server
+      BOLT_HOST: neo4j-server
+      BOLT_PASSWORD: password
+    networks:
+      ci_net:
+        ipv6_address: 2001:3200:3200::21
+
+networks:
+  ci_net:
+    enable_ipv6: true
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+      - subnet: 2001:3200:3200::/64
+        gateway: 2001:3200:3200::1


### PR DESCRIPTION
Adding some functionality to the docker CI tooling to make it easier to develop without access to TeamCity. The following wokflows should now work:

1. using a local server package in a docker container by running the script at ./ci/linux.sh like `NEOCTRL_LOCAL_PACKAGE=path/to/some/neo4j-community-server.tar.gz ./ci/linux.sh` -- which creates a volume pointing to the tarball directory and assigns the `NEOCTRL_LOCAL_PACKAGE` envvar so neoctrl uses it instead of TeamCity
2. via `docker-compose up` -- which will create a server instance container on the same network as the seabolt-ci container and run the tests against it
3. `docker-compose up` and `./build/bin/seabolt-test` -- which will run the tests locally against the neo4j server running in a docker container