### PR TITLE
Pass AccessMode in BEGIN and RUN messages

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -74,9 +74,9 @@ BoltConfig
 
 .. doxygenfunction:: BoltConfig_destroy
 
-.. doxygenfunction:: BoltConfig_get_mode
+.. doxygenfunction:: BoltConfig_get_scheme
 
-.. doxygenfunction:: BoltConfig_set_mode
+.. doxygenfunction:: BoltConfig_set_scheme
 
 .. doxygenfunction:: BoltConfig_get_transport
 
@@ -286,14 +286,16 @@ BoltLog
 .. doxygenfunction:: BoltLog_set_debug_func
 
 
-BoltMode
+BoltScheme
 --------
 
-.. doxygentypedef:: BoltMode
+.. doxygentypedef:: BoltScheme
 
-.. doxygendefine:: BOLT_MODE_DIRECT
+.. doxygendefine:: BOLT_SCHEME_DIRECT
 
-.. doxygendefine:: BOLT_MODE_ROUTING
+.. doxygendefine:: BOLT_SCHEME_ROUTING
+
+.. doxygendefine:: BOLT_SCHEME_NEO4J
 
 
 BoltSocketOptions

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -32,10 +32,6 @@ BoltAddress
 
 .. doxygenfunction:: BoltAddress_port
 
-.. doxygenfunction:: BoltAddress_resolve
-
-.. doxygenfunction:: BoltAddress_copy_resolved_host
-
 
 BoltAddressSet
 --------------
@@ -127,16 +123,6 @@ BoltConnection
 --------------
 
 .. doxygentypedef:: BoltConnection
-
-.. doxygenfunction:: BoltConnection_create
-
-.. doxygenfunction:: BoltConnection_destroy
-
-.. doxygenfunction:: BoltConnection_open
-
-.. doxygenfunction:: BoltConnection_close
-
-.. doxygenfunction:: BoltConnection_init
 
 .. doxygenfunction:: BoltConnection_send
 

--- a/src/seabolt-cli/src/main.c
+++ b/src/seabolt-cli/src/main.c
@@ -213,7 +213,7 @@ struct Application* app_create(int argc, char** argv)
 
     BoltLog* log = create_logger(app->command==CMD_DEBUG);
     BoltConfig* config = BoltConfig_create();
-    BoltConfig_set_mode(config, (strcmp(BOLT_CONFIG_ROUTING, "1")==0) ? BOLT_MODE_ROUTING : BOLT_MODE_DIRECT);
+    BoltConfig_set_scheme(config, (strcmp(BOLT_CONFIG_ROUTING, "1")==0) ? BOLT_SCHEME_NEO4J : BOLT_SCHEME_DIRECT);
     BoltConfig_set_transport(config,
             (strcmp(BOLT_CONFIG_SECURE, "1")==0) ? BOLT_TRANSPORT_ENCRYPTED : BOLT_TRANSPORT_PLAINTEXT);
     BoltConfig_set_user_agent(config, "seabolt/" SEABOLT_VERSION);

--- a/src/seabolt/src/CMakeLists.txt
+++ b/src/seabolt/src/CMakeLists.txt
@@ -21,12 +21,14 @@ list(APPEND private_source_files
         ${CMAKE_CURRENT_LIST_DIR}/bolt/connector.c
         ${CMAKE_CURRENT_LIST_DIR}/bolt/communication.c
         ${CMAKE_CURRENT_LIST_DIR}/bolt/communication-plain.c
+        ${CMAKE_CURRENT_LIST_DIR}/bolt/communication-mock.c
         ${CMAKE_CURRENT_LIST_DIR}/bolt/direct-pool.c
         ${CMAKE_CURRENT_LIST_DIR}/bolt/error.c
         ${CMAKE_CURRENT_LIST_DIR}/bolt/lifecycle.c
         ${CMAKE_CURRENT_LIST_DIR}/bolt/log.c
         ${CMAKE_CURRENT_LIST_DIR}/bolt/mem.c
         ${CMAKE_CURRENT_LIST_DIR}/bolt/name.c
+        ${CMAKE_CURRENT_LIST_DIR}/bolt/no-pool.c
         ${CMAKE_CURRENT_LIST_DIR}/bolt/packstream.c
         ${CMAKE_CURRENT_LIST_DIR}/bolt/protocol.c
         ${CMAKE_CURRENT_LIST_DIR}/bolt/routing-pool.c

--- a/src/seabolt/src/CMakeLists.txt
+++ b/src/seabolt/src/CMakeLists.txt
@@ -242,8 +242,7 @@ endif ()
 include(GenerateExportHeader)
 generate_export_header(${SEABOLT_SHARED}
         BASE_NAME seabolt
-        EXPORT_FILE_NAME "${CMAKE_BINARY_DIR}/${INSTALL_INCLUDEDIR}/bolt/bolt-exports.h"
-        DEFINE_NO_DEPRECATED)
+        EXPORT_FILE_NAME "${CMAKE_BINARY_DIR}/${INSTALL_INCLUDEDIR}/bolt/bolt-exports.h")
 target_compile_definitions(${SEABOLT_STATIC}
         PUBLIC
         SEABOLT_STATIC_DEFINE)

--- a/src/seabolt/src/bolt/address-private.h
+++ b/src/seabolt/src/bolt/address-private.h
@@ -48,6 +48,37 @@ BoltAddress* BoltAddress_create_with_lock(const char* host, const char* port);
 
 BoltAddress* BoltAddress_create_from_string(const char* endpoint_str, uint64_t endpoint_len);
 
+/**
+ * Resolves the original host and port into one or more IP addresses and
+ * a port number.
+ *
+ * This can be carried out more than once on the same
+ * address. Any newly-resolved addresses will replace any previously stored.
+ *
+ * The name resolution is a synchronized operation, i.e. concurrent resolution requests on the same
+ * instance are protected by a mutex.
+ *
+ * @param address the instance to be resolved.
+ * @param n_resolved number of resolved addresses that will be set upon successful resolution.
+ * @param log an optional \ref BoltLog instance to be used for logging purposes.
+ * @returns 0 for success, and non-zero error codes returned from getaddrinfo call on error.
+ */
+int32_t BoltAddress_resolve(BoltAddress* address, int32_t* n_resolved, BoltLog* log);
 
+/**
+ * Copies the textual representation of the resolved IP address at the specified index into an already
+ * allocated buffer.
+ *
+ * If successful, AF_INET or AF_INET6 is returned depending on the address family. If unsuccessful, -1 is returned.
+ * Failure may be a result of a system problem or because the supplied buffer is too small for the address.
+ *
+ * @param address the instance to be queried.
+ * @param index index of the resolved IP address
+ * @param buffer destination buffer to write the IP address's string representation
+ * @param buffer_size size of the buffer
+ * @return address family (AF_INET or AF_INET6) or -1 on error
+ */
+int32_t
+BoltAddress_copy_resolved_host(BoltAddress* address, int32_t index, char* buffer, int32_t buffer_size);
 
 #endif //SEABOLT_ADDRESS_PRIVATE_H

--- a/src/seabolt/src/bolt/address.h
+++ b/src/seabolt/src/bolt/address.h
@@ -60,39 +60,6 @@ SEABOLT_EXPORT const char* BoltAddress_host(BoltAddress* address);
 SEABOLT_EXPORT const char* BoltAddress_port(BoltAddress* address);
 
 /**
- * Resolves the original host and port into one or more IP addresses and
- * a port number.
- *
- * This can be carried out more than once on the same
- * address. Any newly-resolved addresses will replace any previously stored.
- *
- * The name resolution is a synchronized operation, i.e. concurrent resolution requests on the same
- * instance are protected by a mutex.
- *
- * @param address the instance to be resolved.
- * @param n_resolved number of resolved addresses that will be set upon successful resolution.
- * @param log an optional \ref BoltLog instance to be used for logging purposes.
- * @returns 0 for success, and non-zero error codes returned from getaddrinfo call on error.
- */
-SEABOLT_EXPORT int32_t BoltAddress_resolve(BoltAddress* address, int32_t* n_resolved, BoltLog* log);
-
-/**
- * Copies the textual representation of the resolved IP address at the specified index into an already
- * allocated buffer.
- *
- * If successful, AF_INET or AF_INET6 is returned depending on the address family. If unsuccessful, -1 is returned.
- * Failure may be a result of a system problem or because the supplied buffer is too small for the address.
- *
- * @param address the instance to be queried.
- * @param index index of the resolved IP address
- * @param buffer destination buffer to write the IP address's string representation
- * @param buffer_size size of the buffer
- * @return address family (AF_INET or AF_INET6) or -1 on error
- */
-SEABOLT_EXPORT int32_t
-BoltAddress_copy_resolved_host(BoltAddress* address, int32_t index, char* buffer, int32_t buffer_size);
-
-/**
  * Destroys the passed \ref BoltAddress instance.
  *
  * @param address the instance to be destroyed.

--- a/src/seabolt/src/bolt/communication-mock.c
+++ b/src/seabolt/src/bolt/communication-mock.c
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "communication-mock.h"
+#include "bolt-private.h"
+#include "config-private.h"
+#include "mem.h"
+#include "name.h"
+#include "status-private.h"
+#include "log-private.h"
+
+#define MAX_IPADDR_LEN 64
+
+int mock_last_error(BoltCommunication* comm)
+{
+    UNUSED(comm);
+    return BOLT_SUCCESS;
+}
+
+int mock_transform_error(BoltCommunication* comm, int error_code)
+{
+    UNUSED(comm);
+    UNUSED(error_code);
+    return BOLT_SUCCESS;
+}
+
+int mock_socket_ignore_sigpipe(BoltCommunication* comm)
+{
+    BoltLog_debug(comm->log, "socket_ignore_sigpipe");
+    return BOLT_SUCCESS;
+}
+
+int mock_socket_restore_sigpipe(BoltCommunication* comm)
+{
+    BoltLog_debug(comm->log, "socket_restore_sigpipe");
+    return BOLT_SUCCESS;
+}
+
+int mock_socket_open(BoltCommunication* comm, const struct sockaddr_storage* address)
+{
+    BoltLog_debug(comm->log, "socket_open");
+
+    MockCommunicationContext* context = comm->context;
+
+    char resolved_host[MAX_IPADDR_LEN], resolved_port[6];
+    int status = get_address_components(address, resolved_host, MAX_IPADDR_LEN, resolved_port, 6);
+    if (status!=0) {
+        BoltStatus_set_error_with_ctx(comm->status, BOLT_ADDRESS_NAME_INFO_FAILED,
+                "mock_socket_open(%s:%d), remote get_address_components error code: %d", __FILE__, __LINE__, status);
+        return BOLT_STATUS_SET;
+    }
+    context->remote_endpoint = BoltAddress_create(resolved_host, resolved_port);
+    context->local_endpoint = BoltAddress_create("localhost", "65000");
+
+    BoltLog_debug(comm->log, "socket_open: connected");
+
+    return BOLT_SUCCESS;
+}
+
+int mock_socket_close(BoltCommunication* comm)
+{
+    BoltLog_debug(comm->log, "socket_close");
+
+    MockCommunicationContext* context = comm->context;
+
+    if (context->local_endpoint!=NULL) {
+        BoltAddress_destroy(context->local_endpoint);
+        context->local_endpoint = NULL;
+    }
+
+    if (context->remote_endpoint!=NULL) {
+        BoltAddress_destroy(context->remote_endpoint);
+        context->remote_endpoint = NULL;
+    }
+
+    return BOLT_SUCCESS;
+}
+
+int mock_socket_send(BoltCommunication* comm, char* buffer, int length, int* sent)
+{
+    UNUSED(buffer);
+    BoltLog_debug(comm->log, "socket_send: %d bytes", length);
+
+    *sent = length;
+
+    return BOLT_SUCCESS;
+}
+
+int mock_socket_recv(BoltCommunication* comm, char* buffer, int length, int* received)
+{
+    BoltLog_debug(comm->log, "socket_recv: %d bytes", length);
+
+    MockCommunicationContext* context = comm->context;
+    if (!context->protocol_version_sent) {
+        memcpy_be(buffer, &context->protocol_version, sizeof(int32_t));
+        context->protocol_version_sent = 1;
+    }
+
+    *received = length;
+
+    return BOLT_SUCCESS;
+}
+
+int mock_socket_destroy(BoltCommunication* comm)
+{
+    BoltLog_debug(comm->log, "socket_destroy");
+
+    MockCommunicationContext* context = comm->context;
+
+    if (context!=NULL) {
+        if (context->local_endpoint!=NULL) {
+            BoltAddress_destroy(context->local_endpoint);
+            context->local_endpoint = NULL;
+        }
+        if (context->remote_endpoint!=NULL) {
+            BoltAddress_destroy(context->remote_endpoint);
+            context->remote_endpoint = NULL;
+        }
+
+        BoltMem_deallocate(context, sizeof(MockCommunicationContext));
+        comm->context = NULL;
+    }
+
+    return BOLT_SUCCESS;
+}
+
+BoltAddress* mock_socket_local_endpoint(BoltCommunication* comm)
+{
+    MockCommunicationContext* context = comm->context;
+    return context->local_endpoint;
+}
+
+BoltAddress* mock_socket_remote_endpoint(BoltCommunication* comm)
+{
+    MockCommunicationContext* context = comm->context;
+    return context->remote_endpoint;
+}
+
+BoltCommunication*
+BoltCommunication_create_mock(int32_t version, BoltSocketOptions* sock_opts, BoltLog* log)
+{
+    BoltCommunication* comm = BoltMem_allocate(sizeof(BoltCommunication));
+    comm->open = &mock_socket_open;
+    comm->close = &mock_socket_close;
+    comm->send = &mock_socket_send;
+    comm->recv = &mock_socket_recv;
+    comm->destroy = &mock_socket_destroy;
+
+    comm->get_local_endpoint = &mock_socket_local_endpoint;
+    comm->get_remote_endpoint = &mock_socket_remote_endpoint;
+
+    comm->ignore_sigpipe = &mock_socket_ignore_sigpipe;
+    comm->restore_sigpipe = &mock_socket_restore_sigpipe;
+
+    comm->last_error = &mock_last_error;
+    comm->transform_error = &mock_transform_error;
+
+    comm->status_owned = 1;
+    comm->status = BoltStatus_create_with_ctx(1024);
+    comm->sock_opts_owned = sock_opts==NULL;
+    comm->sock_opts = sock_opts==NULL ? BoltSocketOptions_create() : sock_opts;
+    comm->log = log;
+
+    MockCommunicationContext* context = BoltMem_allocate(sizeof(MockCommunicationContext));
+    context->local_endpoint = NULL;
+    context->remote_endpoint = NULL;
+    context->protocol_version = version;
+    context->protocol_version_sent = 0;
+
+    comm->context = context;
+
+    return comm;
+}

--- a/src/seabolt/src/bolt/communication-mock.h
+++ b/src/seabolt/src/bolt/communication-mock.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef SEABOLT_COMMUNICATION_MOCK_H
+#define SEABOLT_COMMUNICATION_MOCK_H
+
+#include "communication.h"
+#include "config.h"
+
+typedef struct MockCommunicationContext {
+    BoltAddress* local_endpoint;
+    BoltAddress* remote_endpoint;
+
+    int32_t protocol_version;
+    int protocol_version_sent;
+} MockCommunicationContext;
+
+BoltCommunication* BoltCommunication_create_mock(int32_t version, BoltSocketOptions* socket_options, BoltLog* log);
+
+#endif //SEABOLT_COMMUNICATION_MOCK_H

--- a/src/seabolt/src/bolt/config-private.h
+++ b/src/seabolt/src/bolt/config-private.h
@@ -21,6 +21,13 @@
 
 #include "config.h"
 
+/**
+ * Use BOLT_SCHEME_CONNECTION to establish connections on-demand to a single server without
+ * any connection pooling kicking in. The returned connection will behave as
+ * BOLT_SCHEME_DIRECT.
+ */
+#define BOLT_SCHEME_DIRECT_UNPOOLED 2
+
 struct BoltTrust {
     char* certs;
     uint64_t certs_len;

--- a/src/seabolt/src/bolt/config-private.h
+++ b/src/seabolt/src/bolt/config-private.h
@@ -43,7 +43,7 @@ struct BoltSocketOptions {
 };
 
 struct BoltConfig {
-    BoltMode mode;
+    BoltScheme scheme;
     BoltTransport transport;
     struct BoltTrust* trust;
     char* user_agent;

--- a/src/seabolt/src/bolt/config.c
+++ b/src/seabolt/src/bolt/config.c
@@ -143,7 +143,7 @@ int32_t BoltTrust_set_skip_verify_hostname(BoltTrust* trust, int32_t skip_verify
 BoltConfig* BoltConfig_create()
 {
     BoltConfig* config = BoltMem_allocate(sizeof(BoltConfig));
-    config->mode = BOLT_MODE_DIRECT;
+    config->scheme = BOLT_SCHEME_DIRECT;
     config->transport = BOLT_TRANSPORT_ENCRYPTED;
     config->trust = NULL;
     config->user_agent = NULL;
@@ -161,7 +161,7 @@ BoltConfig* BoltConfig_clone(BoltConfig* config)
 {
     BoltConfig* clone = BoltConfig_create();
     if (config!=NULL) {
-        BoltConfig_set_mode(clone, config->mode);
+        BoltConfig_set_scheme(clone, config->scheme);
         BoltConfig_set_transport(clone, config->transport);
         BoltConfig_set_trust(clone, config->trust);
         BoltConfig_set_user_agent(clone, config->user_agent);
@@ -199,14 +199,14 @@ void BoltConfig_destroy(BoltConfig* config)
     BoltMem_deallocate(config, sizeof(BoltConfig));
 }
 
-BoltMode BoltConfig_get_mode(BoltConfig* config)
+BoltScheme BoltConfig_get_scheme(BoltConfig* config)
 {
-    return config->mode;
+    return config->scheme;
 }
 
-int32_t BoltConfig_set_mode(BoltConfig* config, BoltMode mode)
+int32_t BoltConfig_set_scheme(BoltConfig* config, BoltScheme scheme)
 {
-    config->mode = mode;
+    config->scheme = scheme;
     return BOLT_SUCCESS;
 }
 

--- a/src/seabolt/src/bolt/config.h
+++ b/src/seabolt/src/bolt/config.h
@@ -26,15 +26,23 @@
 /**
  * The operating mode of the connector.
  */
-typedef int32_t BoltMode;
+typedef int32_t BoltScheme;
 /**
- * Use BOLT_MODE_DIRECT to establish direct connections towards a single server
+ * Use BOLT_SCHEME_DIRECT to establish direct connections towards a single server
  */
-#define BOLT_MODE_DIRECT    0
+#define BOLT_SCHEME_DIRECT    0
+
+#ifndef SEABOLT_NO_DEPRECATED
 /**
- * Use BOLT_MODE_ROUTING to establish routing connections towards a casual cluster.
+ * Use BOLT_SCHEME_ROUTING to establish routing connections towards a casual cluster.
+ * This is deprecated, please use BOLT_SCHEME_NEO4J instead.
  */
-#define BOLT_MODE_ROUTING   1
+#define BOLT_SCHEME_ROUTING  1
+#endif
+/**
+ * Use BOLT_SCHEME_NEO4J to establish routing first connections towards a neo4j server.
+ */
+#define BOLT_SCHEME_NEO4J     1
 
 /**
  * The transport to use for established connections.
@@ -206,21 +214,21 @@ SEABOLT_EXPORT BoltConfig* BoltConfig_create();
 SEABOLT_EXPORT void BoltConfig_destroy(BoltConfig* config);
 
 /**
- * Gets the configured \ref BoltMode "mode".
+ * Gets the configured \ref BoltScheme "scheme".
  *
  * @param config the config instance to query.
- * @return the configured \ref BoltMode "mode".
+ * @return the configured \ref BoltScheme "scheme".
  */
-SEABOLT_EXPORT BoltMode BoltConfig_get_mode(BoltConfig* config);
+SEABOLT_EXPORT BoltScheme BoltConfig_get_scheme(BoltConfig* config);
 
 /**
- * Sets the configured \ref BoltMode "mode".
+ * Sets the configured \ref BoltScheme "scheme".
  *
  * @param config the config instance to modify.
- * @param mode the \ref BoltMode "mode" to set.
+ * @param mode the \ref BoltScheme "scheme" to set.
  * @returns \ref BOLT_SUCCESS when the operation is successful, or another positive error code identifying the reason.
  */
-SEABOLT_EXPORT int32_t BoltConfig_set_mode(BoltConfig* config, BoltMode mode);
+SEABOLT_EXPORT int32_t BoltConfig_set_scheme(BoltConfig* config, BoltScheme scheme);
 
 /**
  * Gets the configured \ref BoltTransport "transport".

--- a/src/seabolt/src/bolt/connection-private.h
+++ b/src/seabolt/src/bolt/connection-private.h
@@ -48,6 +48,7 @@ struct BoltConnectionMetrics {
 struct BoltConnection {
     /// The agent currently responsible for using this connection
     const void* agent;
+    BoltAccessMode access_mode;
 
     /// Transport type for this connection
     BoltTransport transport;

--- a/src/seabolt/src/bolt/connection-private.h
+++ b/src/seabolt/src/bolt/connection-private.h
@@ -20,13 +20,20 @@
 #define SEABOLT_CONNECTION_PRIVATE_H
 
 #include "communication.h"
-#include "communication-secure.h"
 #include "connection.h"
 #include "status-private.h"
+#include "bolt.h"
+
+/**
+ * Use BOLT_TRANSPORT_MOCK to establish a mock connection
+ */
+#define BOLT_TRANSPORT_MOCKED    -1
 
 typedef void (* error_action_func)(struct BoltConnection*, void*);
 
 typedef struct BoltConnectionMetrics BoltConnectionMetrics;
+
+typedef struct BoltSecurityContext BoltSecurityContext;
 
 /**
  * Record of connection usage statistics.
@@ -78,6 +85,69 @@ struct BoltConnection {
     error_action_func on_error_cb;
     void* on_error_cb_state;
 };
+
+/**
+ * Creates a new instance of \ref BoltConnection.
+ *
+ * @return the pointer to the newly allocated \ref BoltConnection instance.
+ */
+BoltConnection* BoltConnection_create();
+
+/**
+ * Destroys the passed \ref BoltConnection instance.
+ *
+ * @param connection the instance to be destroyed.
+ */
+void BoltConnection_destroy(BoltConnection* connection);
+
+/**
+ * Opens a connection to a Bolt server.
+ *
+ * This function attempts to connect a BoltConnection to _address_ over
+ * _transport_. The `address` should be a pointer to a `BoltAddress` struct
+ * that has been successfully resolved.
+ *
+ * This function blocks until the connection attempt succeeds or fails.
+ * On returning, the connection status will be set to either \ref BOLT_CONNECTION_STATE_CONNECTED
+ * (if successful) or \ref BOLT_CONNECTION_STATE_DEFUNCT (if not). If defunct, the actual error code will
+ * be returned.
+ *
+ * In case an error code is returned, more information can be gathered through \ref BoltStatus for which you can
+ * get a reference by calling \ref BoltConnection_status.
+ *
+ * @param connection the instance to attempt the connection.
+ * @param transport the type of transport over which to connect.
+ * @param address the Bolt server address.
+ * @param trust the trust settings to be used for \ref BOLT_TRANSPORT_ENCRYPTED connections.
+ * @param log the logger to be used for logging purposes.
+ * @param sock_opts the socket options to be applied to the underlying socket.
+ * @return \ref BOLT_SUCCESS if the connection was opened successfully,
+ *          an error code otherwise.
+ */
+int32_t BoltConnection_open(BoltConnection* connection, BoltTransport transport,
+        BoltAddress* address, BoltTrust* trust, BoltLog* log, BoltSocketOptions* sock_opts);
+
+/**
+ * Closes the connection.
+ *
+ * @param connection the instance to be closed.
+ */
+void BoltConnection_close(BoltConnection* connection);
+
+/**
+ * Initialise the connection and authenticate using the provided authentication token.
+ *
+ * Returns 0 on success and -1 in case of an error. More information about the underlying error can be gathered
+ * through \ref BoltStatus for which you can get a reference by calling \ref BoltConnection_status.
+ *
+ * @param connection the instance to be initialised and authenticated.
+ * @param user_agent the user agent string to present to the server.
+ * @param auth_token dictionary that contains an authentication token.
+ * @return 0 on success,
+ *        -1 on error.
+ */
+int32_t
+BoltConnection_init(BoltConnection* connection, const char* user_agent, const BoltValue* auth_token);
 
 /**
  * Take an exact amount of data from the receive buffer, deferring to

--- a/src/seabolt/src/bolt/connection.c
+++ b/src/seabolt/src/bolt/connection.c
@@ -203,6 +203,7 @@ BoltConnection* BoltConnection_create()
     const size_t size = sizeof(BoltConnection);
     BoltConnection* connection = BoltMem_allocate(size);
     memset(connection, 0, size);
+    connection->access_mode = BOLT_ACCESS_MODE_WRITE;
     connection->status = BoltStatus_create_with_ctx(ERROR_CTX_SIZE);
     connection->metrics = BoltMem_allocate(sizeof(BoltConnectionMetrics));
     memset(connection->metrics, 0, sizeof(BoltConnectionMetrics));

--- a/src/seabolt/src/bolt/connection.c
+++ b/src/seabolt/src/bolt/connection.c
@@ -30,6 +30,7 @@
 #include "v3.h"
 #include "atomic.h"
 #include "communication-plain.h"
+#include "communication-secure.h"
 
 #define INITIAL_TX_BUFFER_SIZE 8192
 #define INITIAL_RX_BUFFER_SIZE 8192
@@ -240,6 +241,9 @@ BoltConnection_open(BoltConnection* connection, BoltTransport transport, struct 
     case BOLT_TRANSPORT_ENCRYPTED:
         connection->comm = BoltCommunication_create_secure(connection->sec_context, trust, sock_opts, log,
                 connection->address->host, connection->id);
+        break;
+    case BOLT_TRANSPORT_MOCKED:
+        // Expect connection->comm to be explicitly set by the caller
         break;
     }
 

--- a/src/seabolt/src/bolt/connection.h
+++ b/src/seabolt/src/bolt/connection.h
@@ -38,68 +38,6 @@ typedef uint64_t BoltRequest;
  */
 typedef struct BoltConnection BoltConnection;
 
-/**
- * Creates a new instance of \ref BoltConnection.
- *
- * @return the pointer to the newly allocated \ref BoltConnection instance.
- */
-SEABOLT_EXPORT BoltConnection* BoltConnection_create();
-
-/**
- * Destroys the passed \ref BoltConnection instance.
- *
- * @param connection the instance to be destroyed.
- */
-SEABOLT_EXPORT void BoltConnection_destroy(BoltConnection* connection);
-
-/**
- * Opens a connection to a Bolt server.
- *
- * This function attempts to connect a BoltConnection to _address_ over
- * _transport_. The `address` should be a pointer to a `BoltAddress` struct
- * that has been successfully resolved.
- *
- * This function blocks until the connection attempt succeeds or fails.
- * On returning, the connection status will be set to either \ref BOLT_CONNECTION_STATE_CONNECTED
- * (if successful) or \ref BOLT_CONNECTION_STATE_DEFUNCT (if not). If defunct, the actual error code will
- * be returned.
- *
- * In case an error code is returned, more information can be gathered through \ref BoltStatus for which you can
- * get a reference by calling \ref BoltConnection_status.
- *
- * @param connection the instance to attempt the connection.
- * @param transport the type of transport over which to connect.
- * @param address the Bolt server address.
- * @param trust the trust settings to be used for \ref BOLT_TRANSPORT_ENCRYPTED connections.
- * @param log the logger to be used for logging purposes.
- * @param sock_opts the socket options to be applied to the underlying socket.
- * @return \ref BOLT_SUCCESS if the connection was opened successfully,
- *          an error code otherwise.
- */
-SEABOLT_EXPORT int32_t BoltConnection_open(BoltConnection* connection, BoltTransport transport,
-        BoltAddress* address, BoltTrust* trust, BoltLog* log, BoltSocketOptions* sock_opts);
-
-/**
- * Closes the connection.
- *
- * @param connection the instance to be closed.
- */
-SEABOLT_EXPORT void BoltConnection_close(BoltConnection* connection);
-
-/**
- * Initialise the connection and authenticate using the provided authentication token.
- *
- * Returns 0 on success and -1 in case of an error. More information about the underlying error can be gathered
- * through \ref BoltStatus for which you can get a reference by calling \ref BoltConnection_status.
- *
- * @param connection the instance to be initialised and authenticated.
- * @param user_agent the user agent string to present to the server.
- * @param auth_token dictionary that contains an authentication token.
- * @return 0 on success,
- *        -1 on error.
- */
-SEABOLT_EXPORT int32_t
-BoltConnection_init(BoltConnection* connection, const char* user_agent, const BoltValue* auth_token);
 
 /**
  * Sends all of the queued requests.

--- a/src/seabolt/src/bolt/connector.c
+++ b/src/seabolt/src/bolt/connector.c
@@ -123,7 +123,9 @@ BoltConnection* BoltConnector_acquire(BoltConnector* connector, BoltAccessMode m
 void BoltConnector_release(BoltConnector* connector, BoltConnection* connection)
 {
     // Reset access mode stored in connection to its default value
-    connection->access_mode = BOLT_ACCESS_MODE_WRITE;
+    if (connection!=NULL) {
+        connection->access_mode = BOLT_ACCESS_MODE_WRITE;
+    }
 
     switch (connector->config->scheme) {
     case BOLT_SCHEME_DIRECT:

--- a/src/seabolt/src/bolt/connector.c
+++ b/src/seabolt/src/bolt/connector.c
@@ -112,6 +112,7 @@ BoltConnection* BoltConnector_acquire(BoltConnector* connector, BoltAccessMode m
         break;
     }
 
+    // Assign access mode to the returned connection
     if (connection!=NULL) {
         connection->access_mode = mode;
     }
@@ -121,6 +122,9 @@ BoltConnection* BoltConnector_acquire(BoltConnector* connector, BoltAccessMode m
 
 void BoltConnector_release(BoltConnector* connector, BoltConnection* connection)
 {
+    // Reset access mode stored in connection to its default value
+    connection->access_mode = BOLT_ACCESS_MODE_WRITE;
+
     switch (connector->config->scheme) {
     case BOLT_SCHEME_DIRECT:
         BoltDirectPool_release((struct BoltDirectPool*) connector->pool_state, connection);

--- a/src/seabolt/src/bolt/connector.c
+++ b/src/seabolt/src/bolt/connector.c
@@ -24,9 +24,11 @@
 #include "connector-private.h"
 #include "log-private.h"
 #include "direct-pool.h"
+#include "no-pool.h"
 #include "mem.h"
 #include "routing-pool.h"
 #include "status-private.h"
+#include "connection-private.h"
 
 BoltConfig* BoltConnector_apply_defaults(BoltConfig* config)
 {
@@ -50,12 +52,15 @@ BoltConnector_create(BoltAddress* address, BoltValue* auth_token, struct BoltCon
     BoltLog_info(connector->config->log, "[connector]: Version %s [%s]", SEABOLT_VERSION,
             SEABOLT_VERSION_HASH);
 
-    switch (connector->config->mode) {
-    case BOLT_MODE_DIRECT:
+    switch (connector->config->scheme) {
+    case BOLT_SCHEME_DIRECT:
         connector->pool_state = BoltDirectPool_create(address, connector->auth_token, connector->config);
         break;
-    case BOLT_MODE_ROUTING:
+    case BOLT_SCHEME_NEO4J:
         connector->pool_state = BoltRoutingPool_create(address, connector->auth_token, connector->config);
+        break;
+    case BOLT_SCHEME_DIRECT_UNPOOLED:
+        connector->pool_state = BoltNoPool_create(address, connector->auth_token, connector->config);
         break;
     default:
         // TODO: Set some status
@@ -67,12 +72,15 @@ BoltConnector_create(BoltAddress* address, BoltValue* auth_token, struct BoltCon
 
 void BoltConnector_destroy(BoltConnector* connector)
 {
-    switch (connector->config->mode) {
-    case BOLT_MODE_DIRECT:
+    switch (connector->config->scheme) {
+    case BOLT_SCHEME_DIRECT:
         BoltDirectPool_destroy((struct BoltDirectPool*) connector->pool_state);
         break;
-    case BOLT_MODE_ROUTING:
+    case BOLT_SCHEME_NEO4J:
         BoltRoutingPool_destroy((struct BoltRoutingPool*) connector->pool_state);
+        break;
+    case BOLT_SCHEME_DIRECT_UNPOOLED:
+        BoltNoPool_destroy((struct BoltNoPool*) connector->pool_state);
         break;
     }
 
@@ -84,29 +92,44 @@ void BoltConnector_destroy(BoltConnector* connector)
 
 BoltConnection* BoltConnector_acquire(BoltConnector* connector, BoltAccessMode mode, BoltStatus* status)
 {
-    switch (connector->config->mode) {
-    case BOLT_MODE_DIRECT:
-        return BoltDirectPool_acquire((struct BoltDirectPool*) connector->pool_state, status);
-    case BOLT_MODE_ROUTING:
-        return BoltRoutingPool_acquire((struct BoltRoutingPool*) connector->pool_state, mode, status);
+    BoltConnection* connection = NULL;
+
+    switch (connector->config->scheme) {
+    case BOLT_SCHEME_DIRECT:
+        connection = BoltDirectPool_acquire((struct BoltDirectPool*) connector->pool_state, status);
+        break;
+    case BOLT_SCHEME_NEO4J:
+        connection = BoltRoutingPool_acquire((struct BoltRoutingPool*) connector->pool_state, mode, status);
+        break;
+    case BOLT_SCHEME_DIRECT_UNPOOLED:
+        connection = BoltNoPool_acquire((struct BoltNoPool*) connector->pool_state, status);
+        break;
+    default:
+        status->state = BOLT_CONNECTION_STATE_DISCONNECTED;
+        status->error = BOLT_UNSUPPORTED;
+        status->error_ctx = NULL;
+        status->error_ctx_size = 0;
+        break;
     }
 
-    status->state = BOLT_CONNECTION_STATE_DISCONNECTED;
-    status->error = BOLT_UNSUPPORTED;
-    status->error_ctx = NULL;
-    status->error_ctx_size = 0;
+    if (connection!=NULL) {
+        connection->access_mode = mode;
+    }
 
-    return NULL;
+    return connection;
 }
 
 void BoltConnector_release(BoltConnector* connector, BoltConnection* connection)
 {
-    switch (connector->config->mode) {
-    case BOLT_MODE_DIRECT:
+    switch (connector->config->scheme) {
+    case BOLT_SCHEME_DIRECT:
         BoltDirectPool_release((struct BoltDirectPool*) connector->pool_state, connection);
         break;
-    case BOLT_MODE_ROUTING:
+    case BOLT_SCHEME_NEO4J:
         BoltRoutingPool_release((struct BoltRoutingPool*) connector->pool_state, connection);
+        break;
+    case BOLT_SCHEME_DIRECT_UNPOOLED:
+        BoltNoPool_release((struct BoltNoPool*) connector->pool_state, connection);
         break;
     }
 }

--- a/src/seabolt/src/bolt/no-pool.c
+++ b/src/seabolt/src/bolt/no-pool.c
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt-private.h"
+#include "address-private.h"
+#include "atomic.h"
+#include "config-private.h"
+#include "connection-private.h"
+#include "no-pool.h"
+#include "log-private.h"
+#include "mem.h"
+#include "protocol.h"
+#include "sync.h"
+#include "time.h"
+
+#define MAX_ID_LEN 16
+
+static int64_t pool_seq = 0;
+
+int find_open_connection(struct BoltNoPool* pool, struct BoltConnection* connection)
+{
+    for (int i = 0; i<pool->size; i++) {
+        struct BoltConnection* candidate = pool->connections[i];
+        if (candidate==connection) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+struct BoltNoPool* BoltNoPool_create(const struct BoltAddress* address, const struct BoltValue* auth_token,
+        const struct BoltConfig* config)
+{
+    char* id = BoltMem_allocate(MAX_ID_LEN);
+    snprintf(id, MAX_ID_LEN, "pool-%" PRId64, BoltAtomic_increment(&pool_seq));
+    BoltLog_info(config->log, "[%s]: Creating pool towards %s:%s", id, address->host, address->port);
+    struct BoltNoPool* pool = (struct BoltNoPool*) BoltMem_allocate(SIZE_OF_NO_POOL);
+    BoltSync_mutex_create(&pool->mutex);
+    pool->id = id;
+    pool->config = config;
+    pool->address = BoltAddress_create_with_lock(address->host, address->port);
+    pool->auth_token = auth_token;
+    pool->size = 0;
+    pool->connections = NULL;
+    return pool;
+}
+
+void BoltNoPool_destroy(struct BoltNoPool* pool)
+{
+    BoltLog_info(pool->config->log, "[%s]: Destroying non-released connections towards %s:%s", pool->id,
+            pool->address->host,
+            pool->address->port);
+    for (int index = 0; index<pool->size; index++) {
+        BoltConnection_close(pool->connections[index]);
+        BoltConnection_destroy(pool->connections[index]);
+    }
+    BoltMem_deallocate(pool->connections, pool->size*sizeof(BoltConnection*));
+    BoltAddress_destroy(pool->address);
+    BoltMem_deallocate(pool->id, MAX_ID_LEN);
+    BoltSync_mutex_destroy(&pool->mutex);
+    BoltMem_deallocate(pool, SIZE_OF_NO_POOL);
+}
+
+BoltConnection* BoltNoPool_acquire(struct BoltNoPool* pool, BoltStatus* status)
+{
+    int pool_error = BOLT_SUCCESS;
+    BoltConnection* connection = NULL;
+
+    BoltLog_info(pool->config->log, "[%s]: Acquiring connection towards %s:%s", pool->id,
+            pool->address->host, pool->address->port);
+
+    connection = BoltConnection_create();
+
+    switch (BoltAddress_resolve(pool->address, NULL, pool->config->log)) {
+    case 0:
+        break;
+    default:
+        pool_error = BOLT_ADDRESS_NOT_RESOLVED;  // Could not resolve address
+    }
+
+    if (pool_error==BOLT_SUCCESS) {
+        switch (BoltConnection_open(connection, pool->config->transport, pool->address, pool->config->trust,
+                pool->config->log, pool->config->socket_options)) {
+        case 0:
+            break;
+        default:
+            pool_error = BOLT_CONNECTION_HAS_MORE_INFO;  // Could not open socket
+        }
+    }
+
+    if (pool_error==BOLT_SUCCESS) {
+        switch (BoltConnection_init(connection, pool->config->user_agent, pool->auth_token)) {
+        case 0:
+            break;
+        default:
+            pool_error = BOLT_CONNECTION_HAS_MORE_INFO;
+        }
+    }
+
+    switch (pool_error) {
+    case BOLT_SUCCESS: {
+        status->state = connection->status->state;
+        status->error = BOLT_SUCCESS;
+        status->error_ctx = NULL;
+        status->error_ctx_size = 0;
+
+        BoltSync_mutex_lock(&pool->mutex);
+        int index = pool->size;
+        pool->connections = BoltMem_reallocate(pool->connections, pool->size*sizeof(BoltConnection*),
+                (pool->size+1)*sizeof(BoltConnection*));
+        pool->size = pool->size+1;
+        pool->connections[index] = connection;
+        BoltSync_mutex_unlock(&pool->mutex);
+
+        break;
+    }
+    case BOLT_CONNECTION_HAS_MORE_INFO:
+        status->state = connection->status->state;
+        status->error = connection->status->error;
+        status->error_ctx_size = connection->status->error_ctx_size;
+        status->error_ctx = BoltMem_duplicate(connection->status->error_ctx, connection->status->error_ctx_size);
+        break;
+    default:
+        status->state = BOLT_CONNECTION_STATE_DISCONNECTED;
+        status->error = pool_error;
+        status->error_ctx = NULL;
+        status->error_ctx_size = 0;
+        break;
+    }
+
+    return connection;
+}
+
+int BoltNoPool_release(struct BoltNoPool* pool, struct BoltConnection* connection)
+{
+    BoltLog_info(pool->config->log, "[%s]: Closing connection towards %s:%s", pool->id,
+            pool->address->host,
+            pool->address->port);
+
+    BoltSync_mutex_lock(&pool->mutex);
+    int index = find_open_connection(pool, connection);
+    if (index>=0) {
+        for (int i = index; i<pool->size-1; i++) {
+            pool->connections[i] = pool->connections[i+1];
+        }
+        pool->connections = BoltMem_reallocate(pool->connections, pool->size*sizeof(BoltConnection*),
+                (pool->size-1)*sizeof(BoltConnection*));
+        pool->size = pool->size-1;
+    }
+    BoltSync_mutex_unlock(&pool->mutex);
+
+    BoltConnection_close(connection);
+    BoltConnection_destroy(connection);
+
+    return index;
+}
+

--- a/src/seabolt/src/bolt/no-pool.h
+++ b/src/seabolt/src/bolt/no-pool.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file
+ */
+
+#ifndef SEABOLT_NO_POOL_H
+#define SEABOLT_NO_POOL_H
+
+#include "communication-secure.h"
+#include "connector.h"
+#include "sync.h"
+
+/**
+ * Pooling contract for a no-pooling connection acquisition
+ */
+struct BoltNoPool {
+    mutex_t mutex;
+    char* id;
+    struct BoltAddress* address;
+    const struct BoltValue* auth_token;
+    const struct BoltConfig* config;
+    int size;
+    BoltConnection** connections;
+};
+
+#define SIZE_OF_NO_POOL sizeof(struct BoltNoPool)
+#define SIZE_OF_NO_POOL_PTR sizeof(struct BoltNoPool*)
+
+struct BoltNoPool*
+BoltNoPool_create(const struct BoltAddress* address, const struct BoltValue* auth_token,
+        const struct BoltConfig* config);
+
+void BoltNoPool_destroy(struct BoltNoPool* pool);
+
+BoltConnection* BoltNoPool_acquire(struct BoltNoPool* pool, BoltStatus* status);
+
+int BoltNoPool_release(struct BoltNoPool* pool, struct BoltConnection* connection);
+
+#endif //SEABOLT_POOLING_H

--- a/src/seabolt/tests/CMakeLists.txt
+++ b/src/seabolt/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(seabolt-test
         ${CMAKE_CURRENT_LIST_DIR}/test-addressing.cpp
         ${CMAKE_CURRENT_LIST_DIR}/test-chunking-v1.cpp
         ${CMAKE_CURRENT_LIST_DIR}/test-communication.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/test-connection.cpp
         ${CMAKE_CURRENT_LIST_DIR}/test-direct.cpp
         ${CMAKE_CURRENT_LIST_DIR}/test-pooling.cpp
         ${CMAKE_CURRENT_LIST_DIR}/test-values.cpp

--- a/src/seabolt/tests/integration.hpp
+++ b/src/seabolt/tests/integration.hpp
@@ -36,6 +36,7 @@ extern "C"
 #include "bolt/direct-pool.h"
 #include "bolt/v3.h"
 #include "bolt/communication.h"
+#include "bolt/communication-mock.h"
 }
 
 #define SETTING(name, default_value) ((char*)((getenv(name) == nullptr) ? (default_value) : getenv(name)))
@@ -60,6 +61,8 @@ struct BoltConnection* bolt_open_init_b(BoltTransport transport, const char* hos
         const char* user_agent, const struct BoltValue* auth_token);
 
 struct BoltConnection* bolt_open_init_default();
+
+struct BoltConnection* bolt_open_init_mocked(int32_t bolt_version, BoltLog* logger);
 
 struct BoltValue* bolt_basic_auth(const char* username, const char* password);
 

--- a/src/seabolt/tests/seabolt.cpp
+++ b/src/seabolt/tests/seabolt.cpp
@@ -104,6 +104,18 @@ struct BoltConnection* bolt_open_init_default()
     return connection;
 }
 
+struct BoltConnection* bolt_open_init_mocked(int32_t bolt_version, BoltLog* logger)
+{
+    BoltAddress* address = bolt_get_address("localhost", "7687");
+    BoltConnection* connection = BoltConnection_create();
+    connection->comm = BoltCommunication_create_mock(bolt_version, NULL, logger);
+    BoltConnection_open(connection, BOLT_TRANSPORT_MOCKED, address, NULL, logger, NULL);
+    strcpy(connection->id, "id-0");
+    connection->status->state = BOLT_CONNECTION_STATE_READY;
+    BoltAddress_destroy(address);
+    return connection;
+}
+
 void bolt_close_and_destroy_b(struct BoltConnection* connection)
 {
     BoltConnection_close(connection);

--- a/src/seabolt/tests/test-connection.cpp
+++ b/src/seabolt/tests/test-connection.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "catch.hpp"
+#include "integration.hpp"
+
+SCENARIO("BoltConnection")
+{
+    GIVEN("a new constructed BoltConnection") {
+        BoltConnection* connection = BoltConnection_create();
+
+        THEN("access mode should be set to WRITE") {
+            REQUIRE(connection->access_mode==BOLT_ACCESS_MODE_WRITE);
+        }
+
+        THEN("status is not null") {
+            REQUIRE(connection->status!=NULL);
+        }
+
+        THEN("status->state should be DISCONNECTED") {
+            REQUIRE(connection->status->state==BOLT_CONNECTION_STATE_DISCONNECTED);
+        }
+
+        THEN("status->error should be SUCCESS") {
+            REQUIRE(connection->status->error==BOLT_SUCCESS);
+        }
+
+        THEN("status->error_ctx should not be NULL") {
+            REQUIRE(connection->status->error_ctx!=NULL);
+        }
+
+        THEN("metrics is not null") {
+            REQUIRE(connection->metrics!=NULL);
+        }
+
+        BoltConnection_destroy(connection);
+    }
+}

--- a/src/seabolt/tests/test-connection.cpp
+++ b/src/seabolt/tests/test-connection.cpp
@@ -30,7 +30,7 @@ SCENARIO("BoltConnection")
         }
 
         THEN("status is not null") {
-            REQUIRE(connection->status!=NULL);
+            REQUIRE(connection->status!=nullptr);
         }
 
         THEN("status->state should be DISCONNECTED") {
@@ -42,11 +42,11 @@ SCENARIO("BoltConnection")
         }
 
         THEN("status->error_ctx should not be NULL") {
-            REQUIRE(connection->status->error_ctx!=NULL);
+            REQUIRE(connection->status->error_ctx!=nullptr);
         }
 
         THEN("metrics is not null") {
-            REQUIRE(connection->metrics!=NULL);
+            REQUIRE(connection->metrics!=nullptr);
         }
 
         BoltConnection_destroy(connection);

--- a/src/seabolt/tests/test-pooling.cpp
+++ b/src/seabolt/tests/test-pooling.cpp
@@ -27,7 +27,7 @@ SCENARIO("Test using a pooled connection", "[integration][ipv6][secure][pooling]
     GIVEN("a new connection pool") {
         const auto auth_token = BoltAuth_basic(BOLT_USER, BOLT_PASSWORD, NULL);
         struct BoltTrust trust{nullptr, 0, 1, 1};
-        struct BoltConfig config{BOLT_MODE_DIRECT, BOLT_TRANSPORT_ENCRYPTED, &trust, BOLT_USER_AGENT, nullptr, nullptr,
+        struct BoltConfig config{BOLT_SCHEME_DIRECT, BOLT_TRANSPORT_ENCRYPTED, &trust, BOLT_USER_AGENT, nullptr, nullptr,
                                  nullptr,
                                  10, 0, 0, NULL};
         struct BoltConnector* connector = BoltConnector_create(&BOLT_IPV6_ADDRESS, auth_token, &config);
@@ -55,7 +55,7 @@ SCENARIO("Test reusing a pooled connection", "[integration][ipv6][secure][poolin
     GIVEN("a new connection pool with one entry") {
         const auto auth_token = BoltAuth_basic(BOLT_USER, BOLT_PASSWORD, NULL);
         struct BoltTrust trust{nullptr, 0, 1, 1};
-        struct BoltConfig config{BOLT_MODE_DIRECT, BOLT_TRANSPORT_ENCRYPTED, &trust, BOLT_USER_AGENT, nullptr, nullptr,
+        struct BoltConfig config{BOLT_SCHEME_DIRECT, BOLT_TRANSPORT_ENCRYPTED, &trust, BOLT_USER_AGENT, nullptr, nullptr,
                                  nullptr,
                                  1, 0, 0, NULL};
         struct BoltConnector* connector = BoltConnector_create(&BOLT_IPV6_ADDRESS, auth_token, &config);
@@ -89,7 +89,7 @@ SCENARIO("Test reusing a pooled connection that was abandoned", "[integration][i
     GIVEN("a new connection pool with one entry") {
         const auto auth_token = BoltAuth_basic(BOLT_USER, BOLT_PASSWORD, NULL);
         struct BoltTrust trust{nullptr, 0, 1, 1};
-        struct BoltConfig config{BOLT_MODE_DIRECT, BOLT_TRANSPORT_ENCRYPTED, &trust, BOLT_USER_AGENT, nullptr, nullptr,
+        struct BoltConfig config{BOLT_SCHEME_DIRECT, BOLT_TRANSPORT_ENCRYPTED, &trust, BOLT_USER_AGENT, nullptr, nullptr,
                                  nullptr, 1, 0, 0, NULL};
         struct BoltConnector* connector = BoltConnector_create(&BOLT_IPV6_ADDRESS, auth_token, &config);
         WHEN("a connection is acquired, released and acquired again") {
@@ -134,7 +134,7 @@ SCENARIO("Test running out of connections", "[integration][ipv6][secure][pooling
     GIVEN("a new connection pool with one entry") {
         const auto auth_token = BoltAuth_basic(BOLT_USER, BOLT_PASSWORD, NULL);
         struct BoltTrust trust{nullptr, 0, 1, 1};
-        struct BoltConfig config{BOLT_MODE_DIRECT, BOLT_TRANSPORT_ENCRYPTED, &trust, BOLT_USER_AGENT, nullptr, nullptr,
+        struct BoltConfig config{BOLT_SCHEME_DIRECT, BOLT_TRANSPORT_ENCRYPTED, &trust, BOLT_USER_AGENT, nullptr, nullptr,
                                  nullptr,
                                  1, 0, 0, NULL};
         struct BoltConnector* connector = BoltConnector_create(&BOLT_IPV6_ADDRESS, auth_token, &config);

--- a/src/seabolt/tests/test-v3.cpp
+++ b/src/seabolt/tests/test-v3.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <string>
+#include <utils/test-context.h>
 #include "integration.hpp"
 #include "catch.hpp"
 
@@ -26,56 +27,159 @@ using Catch::Matchers::Equals;
 #define CONNECTION_ID_KEY "connection_id"
 #define CONNECTION_ID_KEY_SIZE 13
 
-TEST_CASE("Extract metadata", "[unit]") {
+TEST_CASE("Extract metadata", "[unit]")
+{
     GIVEN("an open and initialised connection") {
-        struct BoltConnection* connection = bolt_open_init_default();
-        if (connection->protocol_version == 3) {
+        TestContext* test_ctx = new TestContext();
+        struct BoltConnection* connection = bolt_open_init_mocked(3, test_ctx->log());
+
+        WHEN("new connection_id would not overrun buffer") {
             BoltValue* metadata = BoltValue_create();
             BoltValue_format_as_Dictionary(metadata, 1);
             BoltDictionary_set_key(metadata, 0, CONNECTION_ID_KEY, CONNECTION_ID_KEY_SIZE);
 
-            WHEN("new connection_id would not overrun buffer") {
-                std::string old_connection_id = BoltConnection_id(connection);
+            std::string old_connection_id = BoltConnection_id(connection);
 
-                std::string value = "foo";
-                BoltValue_format_as_String(
+            std::string value = "foo";
+            BoltValue_format_as_String(
                     BoltDictionary_value(metadata, 0), value.c_str(), (int32_t) value.length());
-                BoltProtocolV3_extract_metadata(connection, metadata);
+            BoltProtocolV3_extract_metadata(connection, metadata);
 
-                std::string connection_id = BoltConnection_id(connection);
+            std::string connection_id = BoltConnection_id(connection);
 
-                REQUIRE(old_connection_id.length() > 0);
-                THEN("it should not be concatenated to a blank with comma") {
-                    REQUIRE_THAT(connection_id, Equals(
-                        old_connection_id + ", " + value
-                    ));
-                }
-            }
-            WHEN("new connection_id would overrun buffer") {
-                THEN("new connection_id should be ignored and the original connection_id should persist") {
-                    std::string old_connection_id = BoltConnection_id(connection);
-                    std::string value =
-                        "0123456789""0123456789""0123456789""0123456789""0123456789"
-                        "0123456789""0123456789""0123456789""0123456789""0123456789"
-                        "0123456789""0123456789""0123456789""0123456789""0123456789"
-                        "0123456789""0123456789""0123456789""0123456789""0123456789"
-                        ;
-                    BoltValue_format_as_String(BoltDictionary_value(metadata, 0), value.c_str(),
-                        (int32_t) value.length());
-                    BoltProtocolV3_extract_metadata(connection, metadata);
-
-                    std::string connection_id = BoltConnection_id(connection);
-
-                    REQUIRE(connection_id.find(value) == std::string::npos);
-                    REQUIRE(connection_id == old_connection_id);
-                }
+            REQUIRE(old_connection_id.length()>0);
+            THEN("it should not be concatenated to a blank with comma") {
+                REQUIRE_THAT(connection_id, Equals(
+                        old_connection_id+", "+value
+                ));
             }
 
             BoltValue_destroy(metadata);
         }
-        else {
-            WARN("Test is skipped because functionality is only available for Bolt V3.");
+
+        WHEN("new connection_id would overrun buffer") {
+            BoltValue* metadata = BoltValue_create();
+            BoltValue_format_as_Dictionary(metadata, 1);
+            BoltDictionary_set_key(metadata, 0, CONNECTION_ID_KEY, CONNECTION_ID_KEY_SIZE);
+
+            THEN("new connection_id should be ignored and the original connection_id should persist") {
+                std::string old_connection_id = BoltConnection_id(connection);
+                std::string value =
+                        "0123456789""0123456789""0123456789""0123456789""0123456789"
+                        "0123456789""0123456789""0123456789""0123456789""0123456789"
+                        "0123456789""0123456789""0123456789""0123456789""0123456789"
+                        "0123456789""0123456789""0123456789""0123456789""0123456789";
+                BoltValue_format_as_String(BoltDictionary_value(metadata, 0), value.c_str(),
+                        (int32_t) value.length());
+                BoltProtocolV3_extract_metadata(connection, metadata);
+
+                std::string connection_id = BoltConnection_id(connection);
+
+                REQUIRE(connection_id.find(value)==std::string::npos);
+                REQUIRE(connection_id==old_connection_id);
+            }
+
+            BoltValue_destroy(metadata);
         }
-        bolt_close_and_destroy_b(connection);
+
+        BoltConnection_close(connection);
+        BoltConnection_destroy(connection);
+    }
+}
+
+TEST_CASE("Pass access mode", "[unit]")
+{
+    GIVEN("an open and initialised connection") {
+        TestContext* test_ctx = new TestContext();
+        struct BoltConnection* connection = bolt_open_init_mocked(3, test_ctx->log());
+
+        BoltValue* tx_metadata = BoltValue_create();
+        BoltValue_format_as_Dictionary(tx_metadata, 2);
+        BoltDictionary_set_key(tx_metadata, 0, "m1", 2);
+        BoltValue_format_as_Integer(BoltDictionary_value(tx_metadata, 0), 10);
+        BoltDictionary_set_key(tx_metadata, 1, "m2", 2);
+        BoltValue_format_as_Boolean(BoltDictionary_value(tx_metadata, 1), 1);
+
+        BoltValue* bookmarks = BoltValue_create();
+        BoltValue_format_as_List(bookmarks, 3);
+        BoltValue_format_as_String(BoltList_value(bookmarks, 0), "bookmark-1", 10);
+        BoltValue_format_as_String(BoltList_value(bookmarks, 1), "bookmark-2", 10);
+        BoltValue_format_as_String(BoltList_value(bookmarks, 2), "bookmark-3", 10);
+
+        WHEN("connection access mode is READ") {
+            connection->access_mode = BOLT_ACCESS_MODE_READ;
+
+            AND_WHEN("a BEGIN message is loaded") {
+                BoltConnection_clear_begin(connection);
+                BoltConnection_set_begin_tx_timeout(connection, 1000);
+                BoltConnection_set_begin_tx_metadata(connection, tx_metadata);
+                BoltConnection_set_begin_bookmarks(connection, bookmarks);
+                BoltConnection_load_begin_request(connection);
+
+                THEN("mode=r should be present in the statement metadata") {
+                    REQUIRE_THAT(*test_ctx,
+                            ContainsLog(
+                                    "DEBUG: [id-0]: C[0] BEGIN [{tx_timeout: 1000, tx_metadata: {m1: 10, m2: true}, "
+                                    "bookmarks: [bookmark-1, bookmark-2, bookmark-3], mode: r}]"));
+                }
+            }
+
+            AND_WHEN("a RUN message is loaded") {
+                BoltConnection_clear_run(connection);
+                BoltConnection_set_run_cypher(connection, "RETURN $x", 9, 1);
+                BoltValue_format_as_Integer(BoltConnection_set_run_cypher_parameter(connection, 0, "x", 1), 5);
+                BoltConnection_set_run_tx_timeout(connection, 5000);
+                BoltConnection_set_run_tx_metadata(connection, tx_metadata);
+                BoltConnection_set_run_bookmarks(connection, bookmarks);
+                BoltConnection_load_run_request(connection);
+
+                THEN("mode=r should be present in the statement metadata") {
+                    REQUIRE_THAT(*test_ctx, ContainsLog(
+                            "DEBUG: [id-0]: C[0] RUN [RETURN $x, {x: 5}, {tx_timeout: 5000, tx_metadata: {m1: 10, m2: true}, "
+                            "bookmarks: [bookmark-1, bookmark-2, bookmark-3], mode: r}]"));
+                }
+            }
+        }
+
+        WHEN("connection access mode is WRITE") {
+            connection->access_mode = BOLT_ACCESS_MODE_WRITE;
+
+            AND_WHEN("a BEGIN message is loaded") {
+                BoltConnection_clear_begin(connection);
+                BoltConnection_set_begin_tx_timeout(connection, 1000);
+                BoltConnection_set_begin_tx_metadata(connection, tx_metadata);
+                BoltConnection_set_begin_bookmarks(connection, bookmarks);
+                BoltConnection_load_begin_request(connection);
+
+                THEN("no access mode should be present in the statement metadata") {
+                    REQUIRE_THAT(*test_ctx,
+                            ContainsLog(
+                                    "DEBUG: [id-0]: C[0] BEGIN [{tx_timeout: 1000, tx_metadata: {m1: 10, m2: true}, "
+                                    "bookmarks: [bookmark-1, bookmark-2, bookmark-3]}]"));
+                }
+            }
+
+            AND_WHEN("a RUN message is loaded") {
+                BoltConnection_clear_run(connection);
+                BoltConnection_set_run_cypher(connection, "RETURN $x", 9, 1);
+                BoltValue_format_as_Integer(BoltConnection_set_run_cypher_parameter(connection, 0, "x", 1), 5);
+                BoltConnection_set_run_tx_timeout(connection, 5000);
+                BoltConnection_set_run_tx_metadata(connection, tx_metadata);
+                BoltConnection_set_run_bookmarks(connection, bookmarks);
+                BoltConnection_load_run_request(connection);
+
+                THEN("no access mode should be present in the statement metadata") {
+                    REQUIRE_THAT(*test_ctx,
+                            ContainsLog(
+                                    "DEBUG: [id-0]: C[0] RUN [RETURN $x, {x: 5}, {tx_timeout: 5000, tx_metadata: {m1: 10, m2: true}, "
+                                    "bookmarks: [bookmark-1, bookmark-2, bookmark-3]}]"));
+                }
+            }
+        }
+
+        BoltValue_destroy(tx_metadata);
+        BoltValue_destroy(bookmarks);
+        BoltConnection_close(connection);
+        BoltConnection_destroy(connection);
     }
 }


### PR DESCRIPTION
This PR makes the `AccessMode` set on client side available on messages BEGIN and RUN in Bolt V3.

No `mode` parameter in statement metadata means that the access mode set by client is `WRITE`, whereas a value of `r` means it is set as `READ`.

It also introduces a couple of breaking changes;

1. Hide some low level connection related APIs, namely `BoltConnection_create`, `BoltConnection_destroy`, `BoltConnection_open`, `BoltConnection_close`, `BoltConnection_init`, `BoltAddress_resolve` and `BoltAddress_copy_resolved_host`.
2. Rename `BoltMode` as `BoltScheme` to better align with naming in uniform drivers. The name change also applies to constants (`BOLT_MODE_DIRECT` -> `BOLT_SCHEME_DIRECT`, `BOLT_MODE_ROUTING` -> `BOLT_SCHEME_ROUTING`).
3. Added `BOLT_SCHEME_NEO4J` as an alias to `BOLT_SCHEME_ROUTING`.