### PR TITLE
Handle SSL_ERROR_ZERO_RETURN code with openssl

### DIFF
--- a/ci/linux/Dockerfile.build
+++ b/ci/linux/Dockerfile.build
@@ -1,13 +1,24 @@
-FROM alpine:3.8 AS build
-RUN apk add --no-cache ca-certificates cmake make g++ openssl-dev git
+FROM debian:stretch AS build
+RUN apt update \
+        && apt install -y ca-certificates make g++ libssl-dev git wget pkg-config \
+        && (mkdir -p /cmake && wget --no-verbose --output-document=- https://cmake.org/files/v3.12/cmake-3.12.3-Linux-x86_64.tar.gz | tar xvz -C /cmake --strip 1) \
+        && rm -rf /var/lib/apt/lists/*
 ADD . /tmp/seabolt
 WORKDIR /tmp/seabolt/build-docker
-RUN cmake -D CMAKE_BUILD_TYPE=Debug -D CMAKE_INSTALL_PREFIX=dist /tmp/seabolt \
-    && cmake --build . --target install
+RUN /cmake/bin/cmake -D CMAKE_BUILD_TYPE=Debug -D CMAKE_INSTALL_PREFIX=dist /tmp/seabolt \
+    && /cmake/bin/cmake --build . --target install
 
-FROM alpine:3.8
-RUN apk add --no-cache bash python3 openjdk11 \
-    && python3 -m pip install boltkit==1.2.0
+FROM openjdk:11-jdk
+RUN apt update \
+    && apt install -y bash python3 python3-pip openjdk-8-jdk \
+    && python3 -m pip install boltkit==1.2.0 \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir /java \
+    && ln -s /usr/lib/jvm/java-11-openjdk-amd64 /java/jdk-4.0 \
+    && ln -s /usr/lib/jvm/java-8-openjdk-amd64 /java/jdk-3.5 \
+    && ln -s /usr/lib/jvm/java-8-openjdk-amd64 /java/jdk-3.4 \
+    && ln -s /usr/lib/jvm/java-8-openjdk-amd64 /java/jdk-3.3 \
+    && ln -s /usr/lib/jvm/java-8-openjdk-amd64 /java/jdk-3.2
 ENV NEOCTRLARGS="-e 3.4"
 ENV TEAMCITY_HOST="" TEAMCITY_USER="" TEAMCITY_PASSWORD=""
 ENV BOLT_HOST="localhost" BOLT_PORT="7687" HTTP_PORT="7474" HTTPS_PORT="7473"
@@ -16,4 +27,4 @@ ADD run_tests.sh /seabolt/
 COPY --from=build /tmp/seabolt/build-docker/bin /seabolt/build/bin/
 COPY --from=build /tmp/seabolt/build-docker/dist /seabolt/build/dist/
 WORKDIR /seabolt
-CMD PYTHON=python3 ./run_tests.sh
+CMD PYTHON=python3 JAVA_HOME=/java/jdk-`echo $NEOCTRLARGS | grep -Po "(-e)?(\s*)\K(\d\.\d)(.\d)?"` ./run_tests.sh

--- a/ci/linux/Dockerfile.build
+++ b/ci/linux/Dockerfile.build
@@ -27,4 +27,4 @@ ADD run_tests.sh /seabolt/
 COPY --from=build /tmp/seabolt/build-docker/bin /seabolt/build/bin/
 COPY --from=build /tmp/seabolt/build-docker/dist /seabolt/build/dist/
 WORKDIR /seabolt
-CMD PYTHON=python3 JAVA_HOME=/java/jdk-`echo $NEOCTRLARGS | grep -Po "(-e)?(\s*)\K(\d\.\d)(.\d)?"` ./run_tests.sh
+CMD PYTHON=python3 JAVA_HOME=/java/jdk-`echo $NEOCTRLARGS | sed -E 's/-e\s*//g' | cut -d. -f1,2` ./run_tests.sh

--- a/ci/linux/Dockerfile.build
+++ b/ci/linux/Dockerfile.build
@@ -6,7 +6,7 @@ RUN cmake -D CMAKE_BUILD_TYPE=Debug -D CMAKE_INSTALL_PREFIX=dist /tmp/seabolt \
     && cmake --build . --target install
 
 FROM alpine:3.8
-RUN apk add --no-cache bash python3 openjdk8 \
+RUN apk add --no-cache bash python3 openjdk11 \
     && python3 -m pip install boltkit==1.2.0
 ENV NEOCTRLARGS="-e 3.4"
 ENV TEAMCITY_HOST="" TEAMCITY_USER="" TEAMCITY_PASSWORD=""

--- a/ci/linux/Dockerfile.package-alpine-3.9
+++ b/ci/linux/Dockerfile.package-alpine-3.9
@@ -1,0 +1,11 @@
+FROM alpine:3.9
+RUN apk add --no-cache ca-certificates cmake make g++ openssl-dev git
+ARG SEABOLT_VERSION
+ARG SEABOLT_VERSION_HASH
+ENV SEABOLT_VERSION=$SEABOLT_VERSION
+ENV SEABOLT_VERSION_HASH=$SEABOLT_VERSION_HASH
+ADD . /tmp/seabolt
+WORKDIR /tmp/seabolt/build-docker
+RUN cmake -D CMAKE_BUILD_TYPE=Release /tmp/seabolt \
+    && cmake --build . --target package
+CMD tar -czf - dist-package/seabolt*

--- a/src/seabolt/src/bolt/address-private.h
+++ b/src/seabolt/src/bolt/address-private.h
@@ -28,9 +28,9 @@ struct BoltAddress {
     const char* port;
 
     /// Number of resolved IP addresses
-    int n_resolved_hosts;
+    volatile int n_resolved_hosts;
     /// Resolved IP address data
-    struct sockaddr_storage* resolved_hosts;
+    volatile struct sockaddr_storage* resolved_hosts;
     /// Resolved port number
     uint16_t resolved_port;
 

--- a/src/seabolt/src/bolt/address-set-private.h
+++ b/src/seabolt/src/bolt/address-set-private.h
@@ -22,8 +22,8 @@
 #include "address-set.h"
 
 struct BoltAddressSet {
-    int32_t size;
-    struct BoltAddress** elements;
+    volatile int32_t size;
+    volatile BoltAddress** elements;
 };
 
 #define SIZE_OF_ADDRESS_SET sizeof(struct BoltAddressSet)

--- a/src/seabolt/src/bolt/address-set.c
+++ b/src/seabolt/src/bolt/address-set.c
@@ -35,7 +35,7 @@ void BoltAddressSet_destroy(BoltAddressSet* set)
     for (int i = 0; i<set->size; i++) {
         BoltAddress_destroy((BoltAddress*) set->elements[i]);
     }
-    BoltMem_deallocate(set->elements, set->size*sizeof(BoltAddress*));
+    BoltMem_deallocate((void*) set->elements, set->size*sizeof(BoltAddress*));
     BoltMem_deallocate(set, SIZE_OF_ADDRESS_SET);
 }
 
@@ -47,7 +47,7 @@ int32_t BoltAddressSet_size(BoltAddressSet* set)
 int32_t BoltAddressSet_index_of(BoltAddressSet* set, const BoltAddress* address)
 {
     for (int i = 0; i<set->size; i++) {
-        BoltAddress* current = (BoltAddress*) set->elements[i];
+        BoltAddress*current = (BoltAddress*) set->elements[i];
 
         if (strcmp(address->host, current->host)==0 && strcmp(address->port, current->port)==0) {
             return i;
@@ -60,7 +60,7 @@ int32_t BoltAddressSet_index_of(BoltAddressSet* set, const BoltAddress* address)
 int32_t BoltAddressSet_add(BoltAddressSet* set, const BoltAddress* address)
 {
     if (BoltAddressSet_index_of(set, address)==-1) {
-        set->elements = BoltMem_reallocate(set->elements, set->size*sizeof(BoltAddress*),
+        set->elements = BoltMem_reallocate((void*) set->elements, set->size*sizeof(BoltAddress*),
                 (set->size+1)*sizeof(BoltAddress*));
         set->elements[set->size] = BoltAddress_create(address->host, address->port);
         set->size++;
@@ -86,7 +86,7 @@ int32_t BoltAddressSet_remove(BoltAddressSet* set, const BoltAddress* address)
         }
 
         BoltAddress_destroy((BoltAddress*) set->elements[index]);
-        BoltMem_deallocate(old_elements, set->size*sizeof(BoltAddress*));
+        BoltMem_deallocate((void*) old_elements, set->size*sizeof(BoltAddress*));
         set->elements = new_elements;
         set->size--;
         return index;
@@ -100,7 +100,7 @@ void BoltAddressSet_replace(BoltAddressSet* dest, BoltAddressSet* source)
         BoltAddress_destroy((BoltAddress*) dest->elements[i]);
     }
 
-    dest->elements = BoltMem_reallocate(dest->elements, dest->size*sizeof(BoltAddress*),
+    dest->elements = BoltMem_reallocate((void*) dest->elements, dest->size*sizeof(BoltAddress*),
             source->size*sizeof(BoltAddress*));
     for (int i = 0; i<source->size; i++) {
         dest->elements[i] = BoltAddress_create(source->elements[i]->host, source->elements[i]->port);

--- a/src/seabolt/src/bolt/address-set.c
+++ b/src/seabolt/src/bolt/address-set.c
@@ -33,7 +33,7 @@ BoltAddressSet* BoltAddressSet_create()
 void BoltAddressSet_destroy(BoltAddressSet* set)
 {
     for (int i = 0; i<set->size; i++) {
-        BoltAddress_destroy(set->elements[i]);
+        BoltAddress_destroy((BoltAddress*) set->elements[i]);
     }
     BoltMem_deallocate(set->elements, set->size*sizeof(BoltAddress*));
     BoltMem_deallocate(set, SIZE_OF_ADDRESS_SET);
@@ -47,7 +47,7 @@ int32_t BoltAddressSet_size(BoltAddressSet* set)
 int32_t BoltAddressSet_index_of(BoltAddressSet* set, const BoltAddress* address)
 {
     for (int i = 0; i<set->size; i++) {
-        struct BoltAddress* current = set->elements[i];
+        BoltAddress* current = (BoltAddress*) set->elements[i];
 
         if (strcmp(address->host, current->host)==0 && strcmp(address->port, current->port)==0) {
             return i;
@@ -60,7 +60,7 @@ int32_t BoltAddressSet_index_of(BoltAddressSet* set, const BoltAddress* address)
 int32_t BoltAddressSet_add(BoltAddressSet* set, const BoltAddress* address)
 {
     if (BoltAddressSet_index_of(set, address)==-1) {
-        set->elements = (struct BoltAddress**) BoltMem_reallocate(set->elements, set->size*sizeof(BoltAddress*),
+        set->elements = BoltMem_reallocate(set->elements, set->size*sizeof(BoltAddress*),
                 (set->size+1)*sizeof(BoltAddress*));
         set->elements[set->size] = BoltAddress_create(address->host, address->port);
         set->size++;
@@ -74,8 +74,8 @@ int32_t BoltAddressSet_remove(BoltAddressSet* set, const BoltAddress* address)
 {
     int index = BoltAddressSet_index_of(set, address);
     if (index>=0) {
-        struct BoltAddress** old_elements = set->elements;
-        struct BoltAddress** new_elements = (struct BoltAddress**) BoltMem_allocate((set->size-1)*sizeof(BoltAddress*));
+        volatile BoltAddress** old_elements = set->elements;
+        volatile BoltAddress** new_elements = BoltMem_allocate((set->size-1)*sizeof(BoltAddress*));
         int new_elements_index = 0;
         for (int i = 0; i<set->size; i++) {
             if (i==index) {
@@ -85,7 +85,7 @@ int32_t BoltAddressSet_remove(BoltAddressSet* set, const BoltAddress* address)
             new_elements[new_elements_index++] = old_elements[i];
         }
 
-        BoltAddress_destroy(set->elements[index]);
+        BoltAddress_destroy((BoltAddress*) set->elements[index]);
         BoltMem_deallocate(old_elements, set->size*sizeof(BoltAddress*));
         set->elements = new_elements;
         set->size--;
@@ -97,10 +97,10 @@ int32_t BoltAddressSet_remove(BoltAddressSet* set, const BoltAddress* address)
 void BoltAddressSet_replace(BoltAddressSet* dest, BoltAddressSet* source)
 {
     for (int i = 0; i<dest->size; i++) {
-        BoltAddress_destroy(dest->elements[i]);
+        BoltAddress_destroy((BoltAddress*) dest->elements[i]);
     }
 
-    dest->elements = (struct BoltAddress**) BoltMem_reallocate(dest->elements, dest->size*sizeof(BoltAddress*),
+    dest->elements = BoltMem_reallocate(dest->elements, dest->size*sizeof(BoltAddress*),
             source->size*sizeof(BoltAddress*));
     for (int i = 0; i<source->size; i++) {
         dest->elements[i] = BoltAddress_create(source->elements[i]->host, source->elements[i]->port);
@@ -111,6 +111,6 @@ void BoltAddressSet_replace(BoltAddressSet* dest, BoltAddressSet* source)
 void BoltAddressSet_add_all(BoltAddressSet* destination, BoltAddressSet* source)
 {
     for (int i = 0; i<source->size; i++) {
-        BoltAddressSet_add(destination, source->elements[i]);
+        BoltAddressSet_add(destination, (BoltAddress*) source->elements[i]);
     }
 }

--- a/src/seabolt/src/bolt/communication-plain-posix.c
+++ b/src/seabolt/src/bolt/communication-plain-posix.c
@@ -49,6 +49,8 @@ int socket_transform_error(BoltCommunication* comm, int error_code)
         return BOLT_CONNECTION_REFUSED;
     case ECONNRESET:
         return BOLT_CONNECTION_RESET;
+    case EPIPE:
+        return BOLT_CONNECTION_RESET;
     case EINTR:
         return BOLT_INTERRUPTED;
     case ENETUNREACH:

--- a/src/seabolt/src/bolt/communication-secure-openssl.c
+++ b/src/seabolt/src/bolt/communication-secure-openssl.c
@@ -124,8 +124,8 @@ BoltSecurityContext_create(struct BoltTrust* trust, const char* hostname, const 
     }
 
     // set auto retry
-    ulong new_mode = (ulong) SSL_CTX_set_mode(context, SSL_MODE_AUTO_RETRY);
-    if ((new_mode & (ulong) SSL_MODE_AUTO_RETRY)!=SSL_MODE_AUTO_RETRY) {
+    unsigned long new_mode = (unsigned long) SSL_CTX_set_mode(context, SSL_MODE_AUTO_RETRY);
+    if ((new_mode & (unsigned long) SSL_MODE_AUTO_RETRY)!=SSL_MODE_AUTO_RETRY) {
         BoltLog_warning(log, "[%s]: Unable to set SSL_MODE_AUTO_RETRY");
     }
 

--- a/src/seabolt/src/bolt/communication-secure-openssl.c
+++ b/src/seabolt/src/bolt/communication-secure-openssl.c
@@ -123,6 +123,12 @@ BoltSecurityContext_create(struct BoltTrust* trust, const char* hostname, const 
         return NULL;
     }
 
+    // set auto retry
+    ulong new_mode = (ulong) SSL_CTX_set_mode(context, SSL_MODE_AUTO_RETRY);
+    if ((new_mode & (ulong) SSL_MODE_AUTO_RETRY)!=SSL_MODE_AUTO_RETRY) {
+        BoltLog_warning(log, "[%s]: Unable to set SSL_MODE_AUTO_RETRY");
+    }
+
     // load trusted certificates
     int status = 1;
     if (trust!=NULL && trust->certs!=NULL && trust->certs_len!=0) {
@@ -245,6 +251,9 @@ int secure_openssl_last_error(BoltCommunication* comm, int ssl_ret, int* ssl_err
         *last_error = ctx->plain_comm->last_error(ctx->plain_comm);
         if (*last_error==0) {
             *last_error = last_error_saved;
+        }
+        if (*last_error==0) {
+            return BOLT_END_OF_TRANSMISSION;
         }
         return ctx->plain_comm->transform_error(ctx->plain_comm, *last_error);
     }

--- a/src/seabolt/src/bolt/communication-secure-openssl.c
+++ b/src/seabolt/src/bolt/communication-secure-openssl.c
@@ -248,6 +248,9 @@ int secure_openssl_last_error(BoltCommunication* comm, int ssl_ret, int* ssl_err
         }
         return ctx->plain_comm->transform_error(ctx->plain_comm, *last_error);
     }
+    case SSL_ERROR_ZERO_RETURN: {
+        return BOLT_END_OF_TRANSMISSION;
+    }
     default:
         return BOLT_TLS_ERROR;
     }

--- a/src/seabolt/src/bolt/communication.c
+++ b/src/seabolt/src/bolt/communication.c
@@ -84,7 +84,7 @@ int BoltCommunication_open(BoltCommunication* comm, BoltAddress* address, const 
 
     int status = BOLT_SUCCESS;
     for (int i = 0; i<address->n_resolved_hosts; i++) {
-        status = _open(comm, &address->resolved_hosts[i], id);
+        status = _open(comm, (struct sockaddr_storage*) &address->resolved_hosts[i], id);
         if (status==BOLT_SUCCESS) {
             BoltAddress* remote = comm->get_remote_endpoint(comm);
             BoltLog_info(comm->log, "[%s]: Remote endpoint is %s:%s", id, remote->host, remote->port);

--- a/src/seabolt/src/bolt/direct-pool.h
+++ b/src/seabolt/src/bolt/direct-pool.h
@@ -28,10 +28,7 @@
 #include "connector.h"
 #include "sync.h"
 
-/**
- * Connection pool (experimental)
- */
-struct BoltDirectPool {
+typedef struct BoltDirectPool {
     mutex_t mutex;
     cond_t released_cond;
     char* id;
@@ -41,7 +38,7 @@ struct BoltDirectPool {
     BoltSecurityContext* sec_context;
     int size;
     BoltConnection** connections;
-};
+} BoltDirectPool;
 
 #define SIZE_OF_DIRECT_POOL sizeof(struct BoltDirectPool)
 #define SIZE_OF_DIRECT_POOL_PTR sizeof(struct BoltDirectPool*)

--- a/src/seabolt/src/bolt/no-pool.c
+++ b/src/seabolt/src/bolt/no-pool.c
@@ -36,7 +36,7 @@ static int64_t pool_seq = 0;
 int find_open_connection(struct BoltNoPool* pool, struct BoltConnection* connection)
 {
     for (int i = 0; i<pool->size; i++) {
-        struct BoltConnection* candidate = pool->connections[i];
+        BoltConnection* candidate = (BoltConnection*) pool->connections[i];
         if (candidate==connection) {
             return i;
         }
@@ -67,8 +67,9 @@ void BoltNoPool_destroy(struct BoltNoPool* pool)
             pool->address->host,
             pool->address->port);
     for (int index = 0; index<pool->size; index++) {
-        BoltConnection_close(pool->connections[index]);
-        BoltConnection_destroy(pool->connections[index]);
+        BoltConnection* connection = (BoltConnection*)pool->connections[index];
+        BoltConnection_close(connection);
+        BoltConnection_destroy(connection);
     }
     BoltMem_deallocate(pool->connections, pool->size*sizeof(BoltConnection*));
     BoltAddress_destroy(pool->address);

--- a/src/seabolt/src/bolt/no-pool.c
+++ b/src/seabolt/src/bolt/no-pool.c
@@ -36,7 +36,7 @@ static int64_t pool_seq = 0;
 int find_open_connection(struct BoltNoPool* pool, struct BoltConnection* connection)
 {
     for (int i = 0; i<pool->size; i++) {
-        BoltConnection* candidate = (BoltConnection*) pool->connections[i];
+        BoltConnection*candidate = (BoltConnection*) pool->connections[i];
         if (candidate==connection) {
             return i;
         }
@@ -67,11 +67,11 @@ void BoltNoPool_destroy(struct BoltNoPool* pool)
             pool->address->host,
             pool->address->port);
     for (int index = 0; index<pool->size; index++) {
-        BoltConnection* connection = (BoltConnection*)pool->connections[index];
+        BoltConnection*connection = (BoltConnection*) pool->connections[index];
         BoltConnection_close(connection);
         BoltConnection_destroy(connection);
     }
-    BoltMem_deallocate(pool->connections, pool->size*sizeof(BoltConnection*));
+    BoltMem_deallocate((void*) pool->connections, pool->size*sizeof(BoltConnection*));
     BoltAddress_destroy(pool->address);
     BoltMem_deallocate(pool->id, MAX_ID_LEN);
     BoltSync_mutex_destroy(&pool->mutex);
@@ -81,7 +81,7 @@ void BoltNoPool_destroy(struct BoltNoPool* pool)
 BoltConnection* BoltNoPool_acquire(struct BoltNoPool* pool, BoltStatus* status)
 {
     int pool_error = BOLT_SUCCESS;
-    BoltConnection* connection = NULL;
+    BoltConnection*connection = NULL;
 
     BoltLog_info(pool->config->log, "[%s]: Acquiring connection towards %s:%s", pool->id,
             pool->address->host, pool->address->port);
@@ -123,7 +123,7 @@ BoltConnection* BoltNoPool_acquire(struct BoltNoPool* pool, BoltStatus* status)
 
         BoltSync_mutex_lock(&pool->mutex);
         int index = pool->size;
-        pool->connections = BoltMem_reallocate(pool->connections, pool->size*sizeof(BoltConnection*),
+        pool->connections = BoltMem_reallocate((void*) pool->connections, pool->size*sizeof(BoltConnection*),
                 (pool->size+1)*sizeof(BoltConnection*));
         pool->size = pool->size+1;
         pool->connections[index] = connection;
@@ -160,7 +160,7 @@ int BoltNoPool_release(struct BoltNoPool* pool, struct BoltConnection* connectio
         for (int i = index; i<pool->size-1; i++) {
             pool->connections[i] = pool->connections[i+1];
         }
-        pool->connections = BoltMem_reallocate(pool->connections, pool->size*sizeof(BoltConnection*),
+        pool->connections = BoltMem_reallocate((void*) pool->connections, pool->size*sizeof(BoltConnection*),
                 (pool->size-1)*sizeof(BoltConnection*));
         pool->size = pool->size-1;
     }

--- a/src/seabolt/src/bolt/no-pool.h
+++ b/src/seabolt/src/bolt/no-pool.h
@@ -37,8 +37,8 @@ struct BoltNoPool {
     struct BoltAddress* address;
     const struct BoltValue* auth_token;
     const struct BoltConfig* config;
-    int size;
-    BoltConnection** connections;
+    volatile int size;
+    volatile BoltConnection** connections;
 };
 
 #define SIZE_OF_NO_POOL sizeof(struct BoltNoPool)

--- a/src/seabolt/src/bolt/routing-pool.c
+++ b/src/seabolt/src/bolt/routing-pool.c
@@ -340,7 +340,6 @@ void BoltRoutingPool_forget_server(struct BoltRoutingPool* pool, const struct Bo
     }
 
     RoutingTable_forget_server(pool->routing_table, server);
-    BoltRoutingPool_cleanup(pool);
 
     // Unlock
     BoltSync_rwlock_wrunlock(&pool->rwlock);
@@ -356,7 +355,6 @@ void BoltRoutingPool_forget_writer(struct BoltRoutingPool* pool, const struct Bo
     }
 
     RoutingTable_forget_writer(pool->routing_table, server);
-    BoltRoutingPool_cleanup(pool);
 
     // Unlock
     BoltSync_rwlock_wrunlock(&pool->rwlock);

--- a/src/seabolt/src/bolt/routing-pool.c
+++ b/src/seabolt/src/bolt/routing-pool.c
@@ -34,15 +34,12 @@
 
 int BoltRoutingPool_ensure_server(struct BoltRoutingPool* pool, const struct BoltAddress* server)
 {
-    int index = -1;
+    int index = BoltAddressSet_index_of(pool->servers, server);
     while (index<0) {
-        index = BoltAddressSet_index_of(pool->servers, server);
-
         // Release read lock
         BoltSync_rwlock_rdunlock(&pool->rwlock);
 
         if (BoltSync_rwlock_timedwrlock(&pool->rwlock, WRITE_LOCK_TIMEOUT)) {
-
             // Check once more if any other thread added this server in the mean-time
             index = BoltAddressSet_index_of(pool->servers, server);
             if (index<0) {

--- a/src/seabolt/src/bolt/routing-pool.c
+++ b/src/seabolt/src/bolt/routing-pool.c
@@ -34,7 +34,7 @@
 
 int BoltRoutingPool_ensure_server(struct BoltRoutingPool* pool, const struct BoltAddress* server)
 {
-    BoltAddressSet* servers = (BoltAddressSet*) pool->servers;
+    BoltAddressSet*servers = (BoltAddressSet*) pool->servers;
 
     int index = BoltAddressSet_index_of(servers, server);
     while (index<0) {
@@ -49,7 +49,7 @@ int BoltRoutingPool_ensure_server(struct BoltRoutingPool* pool, const struct Bol
                 index = BoltAddressSet_add(servers, server);
 
                 // Expand the direct pools and create a new one for this server
-                pool->server_pools = BoltMem_reallocate(pool->server_pools,
+                pool->server_pools = BoltMem_reallocate((void*) pool->server_pools,
                         (pool->servers->size-1)*SIZE_OF_DIRECT_POOL_PTR, (pool->servers->size)*SIZE_OF_DIRECT_POOL_PTR);
                 pool->server_pools[index] = BoltDirectPool_create(server, pool->auth_token, pool->config);
             }
@@ -233,7 +233,7 @@ void BoltRoutingPool_cleanup(struct BoltRoutingPool* pool)
         }
 
         BoltAddressSet_destroy((BoltAddressSet*) old_servers);
-        BoltMem_deallocate(old_server_pools, old_size*SIZE_OF_DIRECT_POOL_PTR);
+        BoltMem_deallocate((void*) old_server_pools, old_size*SIZE_OF_DIRECT_POOL_PTR);
     }
 
     BoltMem_deallocate(cleanup_marker, old_size*sizeof(int));
@@ -462,7 +462,7 @@ void BoltRoutingPool_destroy(struct BoltRoutingPool* pool)
     for (int i = 0; i<pool->servers->size; i++) {
         BoltDirectPool_destroy((BoltDirectPool*) pool->server_pools[i]);
     }
-    BoltMem_deallocate(pool->server_pools, pool->servers->size*SIZE_OF_DIRECT_POOL_PTR);
+    BoltMem_deallocate((void*) pool->server_pools, pool->servers->size*SIZE_OF_DIRECT_POOL_PTR);
     BoltAddressSet_destroy((BoltAddressSet*) pool->servers);
 
     RoutingTable_destroy(pool->routing_table);
@@ -496,7 +496,7 @@ BoltConnection* BoltRoutingPool_acquire(struct BoltRoutingPool* pool, BoltAccess
         }
     }
 
-    BoltConnection* connection = NULL;
+    BoltConnection*connection = NULL;
     if (result==BOLT_SUCCESS) {
         connection = BoltDirectPool_acquire((BoltDirectPool*) pool->server_pools[server_pool_index], status);
         if (connection!=NULL) {

--- a/src/seabolt/src/bolt/routing-pool.h
+++ b/src/seabolt/src/bolt/routing-pool.h
@@ -33,8 +33,8 @@ struct BoltRoutingPool {
     int64_t readers_offset;
     int64_t writers_offset;
 
-    struct BoltAddressSet* servers;
-    struct BoltDirectPool** server_pools;
+    volatile BoltAddressSet* servers;
+    volatile BoltDirectPool** server_pools;
 
     rwlock_t rwlock;
 };

--- a/src/seabolt/src/bolt/sync-pthread.c
+++ b/src/seabolt/src/bolt/sync-pthread.c
@@ -65,17 +65,14 @@ int BoltSync_mutex_trylock(mutex_t* mutex)
 int BoltSync_rwlock_create(rwlock_t* rwlock)
 {
     *rwlock = BoltMem_allocate(sizeof(pthread_rwlock_t));
-
-    pthread_rwlockattr_t rwlock_attr;
-    pthread_rwlockattr_init(&rwlock_attr);
-
-    return pthread_rwlock_init(*rwlock, &rwlock_attr)==0;
+    return pthread_rwlock_init(*rwlock, NULL)==0;
 }
 
 int BoltSync_rwlock_destroy(rwlock_t* rwlock)
 {
     int status = pthread_rwlock_destroy(*rwlock)==0;
     BoltMem_deallocate(*rwlock, sizeof(pthread_rwlock_t));
+    *rwlock = NULL;
     return status;
 }
 

--- a/src/seabolt/src/bolt/v1.c
+++ b/src/seabolt/src/bolt/v1.c
@@ -163,8 +163,8 @@ void ensure_failure_data(struct BoltProtocolV1State* state)
     if (state->failure_data==NULL) {
         state->failure_data = BoltValue_create();
         BoltValue_format_as_Dictionary(state->failure_data, 2);
-        BoltDictionary_set_key(state->failure_data, 0, "code", (int32_t)strlen("code"));
-        BoltDictionary_set_key(state->failure_data, 1, "message", (int32_t)strlen("message"));
+        BoltDictionary_set_key(state->failure_data, 0, "code", (int32_t) strlen("code"));
+        BoltDictionary_set_key(state->failure_data, 1, "message", (int32_t) strlen("message"));
     }
 }
 
@@ -276,7 +276,7 @@ struct BoltValue* BoltProtocolV1_set_run_cypher_parameter(struct BoltConnection*
 {
     struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
     struct BoltValue* params = BoltMessage_param(state->run_request, 1);
-    BoltDictionary_set_key(params, index, name, (int32_t)name_size);
+    BoltDictionary_set_key(params, index, name, (int32_t) name_size);
     return BoltDictionary_value(params, index);
 }
 
@@ -691,7 +691,6 @@ int BoltProtocolV1_fetch(struct BoltConnection* connection, BoltRequest request_
         char header[2];
         int status = BoltConnection_receive(connection, &header[0], 2);
         if (status!=BOLT_SUCCESS) {
-            BoltLog_error(connection->log, "[%s]: Could not fetch chunk header", BoltConnection_id(connection));
             return -1;
         }
         uint16_t chunk_size = char_to_uint16be(header);
@@ -700,12 +699,10 @@ int BoltProtocolV1_fetch(struct BoltConnection* connection, BoltRequest request_
             status = BoltConnection_receive(connection, BoltBuffer_load_pointer(state->rx_buffer, chunk_size),
                     chunk_size);
             if (status!=BOLT_SUCCESS) {
-                BoltLog_error(connection->log, "[%s]: Could not fetch chunk data", BoltConnection_id(connection));
                 return -1;
             }
             status = BoltConnection_receive(connection, &header[0], 2);
             if (status!=BOLT_SUCCESS) {
-                BoltLog_error(connection->log, "[%s]: Could not fetch chunk header", BoltConnection_id(connection));
                 return -1;
             }
             chunk_size = char_to_uint16be(header);

--- a/src/seabolt/src/bolt/v3.c
+++ b/src/seabolt/src/bolt/v3.c
@@ -1012,7 +1012,6 @@ int BoltProtocolV3_fetch(struct BoltConnection* connection, BoltRequest request_
         char header[2];
         int status = BoltConnection_receive(connection, &header[0], 2);
         if (status!=BOLT_SUCCESS) {
-            BoltLog_error(connection->log, "[%s]: Could not fetch chunk header", BoltConnection_id(connection));
             return -1;
         }
         uint16_t chunk_size = char_to_uint16be(header);
@@ -1021,12 +1020,10 @@ int BoltProtocolV3_fetch(struct BoltConnection* connection, BoltRequest request_
             status = BoltConnection_receive(connection, BoltBuffer_load_pointer(state->rx_buffer, chunk_size),
                     chunk_size);
             if (status!=BOLT_SUCCESS) {
-                BoltLog_error(connection->log, "[%s]: Could not fetch chunk data", BoltConnection_id(connection));
                 return -1;
             }
             status = BoltConnection_receive(connection, &header[0], 2);
             if (status!=BOLT_SUCCESS) {
-                BoltLog_error(connection->log, "[%s]: Could not fetch chunk header", BoltConnection_id(connection));
                 return -1;
             }
             chunk_size = char_to_uint16be(header);

--- a/src/seabolt/src/bolt/v3.c
+++ b/src/seabolt/src/bolt/v3.c
@@ -63,7 +63,7 @@
 #define MAX_CONNECTION_ID_SIZE 200
 #define MAX_LOGGED_RECORDS 3
 
-#define char_to_uint16be(array) ((uint8_t)(header[0]) << 8) | (uint8_t)(header[1]);
+#define char_to_uint16be(array) ((uint8_t)(header[0]) << 8) | (uint8_t)(header[1])
 
 #define TRY(code) { int status_try = (code); if (status_try != BOLT_SUCCESS) { return status_try; } }
 

--- a/src/seabolt/tests/test-communication.cpp
+++ b/src/seabolt/tests/test-communication.cpp
@@ -233,8 +233,10 @@ TEST_CASE("communication", "[unit]")
             BoltAddress* remote = BoltAddress_create("127.0.0.1", "7687");
             remote->n_resolved_hosts = 2;
             remote->resolved_hosts = (struct sockaddr_storage*) malloc(2*sizeof(struct sockaddr_storage));
-            remote->resolved_hosts[0] = remote1->resolved_hosts[0];
-            remote->resolved_hosts[1] = remote2->resolved_hosts[0];
+            memcpy((void*) &remote->resolved_hosts[0], (void*) &remote1->resolved_hosts[0],
+                    sizeof(struct sockaddr_storage));
+            memcpy((void*) &remote->resolved_hosts[1], (void*) &remote2->resolved_hosts[0],
+                    sizeof(struct sockaddr_storage));
 
             test_ctx->reset();
 


### PR DESCRIPTION
This PR fixes a couple of issues;

1. Since we're using synchronous sockets, we enable `SSL_MODE_AUTO_RETRY` on OpenSSL connections,
2. Handle `SSL_ERROR_ZERO_RETURN` and also `SSL_SYS_ERROR` with underlying error code of `0` as `BOLT_END_OF_TRANSMISSION`,
3. Handle `EPIPE` errors as `BOLT_END_OF_TRANSMISSION`,
4. Add `volatile` modifier to `struct` fields which gets reallocated over time to avoid reading stale memory locations,
5. Defer pool cleanup to routing table refresh,
6. Introduce alpine-3.9 packaging scripts.