### PR TITLE
Fix concurrent memory issues

### DIFF
--- a/src/seabolt/src/bolt/address-resolver-private.h
+++ b/src/seabolt/src/bolt/address-resolver-private.h
@@ -28,7 +28,7 @@ struct BoltAddressResolver {
 
 BoltAddressResolver* BoltAddressResolver_clone(BoltAddressResolver* resolver);
 
-void BoltAddressResolver_resolve(BoltAddressResolver* resolver, BoltAddress* address,
-        BoltAddressSet* resolved);
+void BoltAddressResolver_resolve(BoltAddressResolver* resolver, const BoltAddress* address,
+        volatile BoltAddressSet* resolved);
 
 #endif //SEABOLT_ADDRESS_RESOLVER_PRIVATE_H

--- a/src/seabolt/src/bolt/address-resolver.c
+++ b/src/seabolt/src/bolt/address-resolver.c
@@ -44,10 +44,11 @@ void BoltAddressResolver_destroy(BoltAddressResolver* resolver)
     BoltMem_deallocate(resolver, sizeof(BoltAddressResolver));
 }
 
-void BoltAddressResolver_resolve(BoltAddressResolver* resolver, BoltAddress* address, struct BoltAddressSet* resolved)
+void BoltAddressResolver_resolve(BoltAddressResolver* resolver, const BoltAddress* address,
+        volatile BoltAddressSet* resolved)
 {
     if (resolver!=NULL && resolver->resolver!=NULL) {
-        resolver->resolver(resolver->state, address, resolved);
+        resolver->resolver(resolver->state, (BoltAddress*) address, (BoltAddressSet*) resolved);
     }
 }
 

--- a/src/seabolt/src/bolt/address-set-private.h
+++ b/src/seabolt/src/bolt/address-set-private.h
@@ -29,18 +29,18 @@ struct BoltAddressSet {
 #define SIZE_OF_ADDRESS_SET sizeof(struct BoltAddressSet)
 #define SIZE_OF_ADDRESS_SET_PTR sizeof(struct BoltAddressSet*)
 
-BoltAddressSet* BoltAddressSet_create();
+volatile BoltAddressSet* BoltAddressSet_create();
 
-void BoltAddressSet_destroy(BoltAddressSet* set);
+void BoltAddressSet_destroy(volatile BoltAddressSet* set);
 
-int32_t BoltAddressSet_size(BoltAddressSet* set);
+int32_t BoltAddressSet_size(volatile BoltAddressSet* set);
 
-int32_t BoltAddressSet_index_of(BoltAddressSet* set, const BoltAddress* address);
+int32_t BoltAddressSet_index_of(volatile BoltAddressSet* set, volatile const BoltAddress* address);
 
-int32_t BoltAddressSet_remove(BoltAddressSet* set, const BoltAddress* address);
+int32_t BoltAddressSet_remove(volatile BoltAddressSet* set, volatile const BoltAddress* address);
 
-void BoltAddressSet_replace(BoltAddressSet* destination, BoltAddressSet* source);
+void BoltAddressSet_replace(volatile BoltAddressSet* destination, volatile BoltAddressSet* source);
 
-void BoltAddressSet_add_all(BoltAddressSet* destination, BoltAddressSet* source);
+void BoltAddressSet_add_all(volatile BoltAddressSet* destination, volatile BoltAddressSet* source);
 
 #endif //SEABOLT_ADDRESS_SET_PRIVATE_H

--- a/src/seabolt/src/bolt/address-set.c
+++ b/src/seabolt/src/bolt/address-set.c
@@ -22,7 +22,7 @@
 #include "address-set-private.h"
 #include "mem.h"
 
-BoltAddressSet* BoltAddressSet_create()
+volatile BoltAddressSet* BoltAddressSet_create()
 {
     struct BoltAddressSet* set = (struct BoltAddressSet*) BoltMem_allocate(SIZE_OF_ADDRESS_SET);
     set->size = 0;
@@ -30,24 +30,24 @@ BoltAddressSet* BoltAddressSet_create()
     return set;
 }
 
-void BoltAddressSet_destroy(BoltAddressSet* set)
+void BoltAddressSet_destroy(volatile BoltAddressSet* set)
 {
     for (int i = 0; i<set->size; i++) {
         BoltAddress_destroy((BoltAddress*) set->elements[i]);
     }
     BoltMem_deallocate((void*) set->elements, set->size*sizeof(BoltAddress*));
-    BoltMem_deallocate(set, SIZE_OF_ADDRESS_SET);
+    BoltMem_deallocate((void*) set, SIZE_OF_ADDRESS_SET);
 }
 
-int32_t BoltAddressSet_size(BoltAddressSet* set)
+int32_t BoltAddressSet_size(volatile BoltAddressSet* set)
 {
     return set->size;
 }
 
-int32_t BoltAddressSet_index_of(BoltAddressSet* set, const BoltAddress* address)
+int32_t BoltAddressSet_index_of(volatile BoltAddressSet* set, volatile const BoltAddress* address)
 {
     for (int i = 0; i<set->size; i++) {
-        BoltAddress*current = (BoltAddress*) set->elements[i];
+        volatile BoltAddress* current = set->elements[i];
 
         if (strcmp(address->host, current->host)==0 && strcmp(address->port, current->port)==0) {
             return i;
@@ -57,7 +57,7 @@ int32_t BoltAddressSet_index_of(BoltAddressSet* set, const BoltAddress* address)
     return -1;
 }
 
-int32_t BoltAddressSet_add(BoltAddressSet* set, const BoltAddress* address)
+int32_t BoltAddressSet_add(volatile BoltAddressSet* set, volatile const BoltAddress* address)
 {
     if (BoltAddressSet_index_of(set, address)==-1) {
         set->elements = BoltMem_reallocate((void*) set->elements, set->size*sizeof(BoltAddress*),
@@ -70,7 +70,7 @@ int32_t BoltAddressSet_add(BoltAddressSet* set, const BoltAddress* address)
     return -1;
 }
 
-int32_t BoltAddressSet_remove(BoltAddressSet* set, const BoltAddress* address)
+int32_t BoltAddressSet_remove(volatile BoltAddressSet* set, volatile const BoltAddress* address)
 {
     int index = BoltAddressSet_index_of(set, address);
     if (index>=0) {
@@ -94,7 +94,7 @@ int32_t BoltAddressSet_remove(BoltAddressSet* set, const BoltAddress* address)
     return -1;
 }
 
-void BoltAddressSet_replace(BoltAddressSet* dest, BoltAddressSet* source)
+void BoltAddressSet_replace(volatile BoltAddressSet* dest, volatile BoltAddressSet* source)
 {
     for (int i = 0; i<dest->size; i++) {
         BoltAddress_destroy((BoltAddress*) dest->elements[i]);
@@ -108,7 +108,7 @@ void BoltAddressSet_replace(BoltAddressSet* dest, BoltAddressSet* source)
     dest->size = source->size;
 }
 
-void BoltAddressSet_add_all(BoltAddressSet* destination, BoltAddressSet* source)
+void BoltAddressSet_add_all(volatile BoltAddressSet* destination, volatile BoltAddressSet* source)
 {
     for (int i = 0; i<source->size; i++) {
         BoltAddressSet_add(destination, (BoltAddress*) source->elements[i]);

--- a/src/seabolt/src/bolt/address-set.h
+++ b/src/seabolt/src/bolt/address-set.h
@@ -38,6 +38,6 @@ typedef struct BoltAddressSet BoltAddressSet;
  * @returns -1 if the provided address is already a member of the set, or the index at which the given address
  * is added.
  */
-SEABOLT_EXPORT int32_t BoltAddressSet_add(BoltAddressSet* set, const BoltAddress* address);
+SEABOLT_EXPORT int32_t BoltAddressSet_add(volatile BoltAddressSet* set, volatile const BoltAddress* address);
 
 #endif //SEABOLT_ALL_ADDRESS_SET_H

--- a/src/seabolt/src/bolt/address.c
+++ b/src/seabolt/src/bolt/address.c
@@ -153,7 +153,7 @@ int32_t BoltAddress_resolve(BoltAddress* address, int32_t* n_resolved, BoltLog* 
     }
 
     if (address->n_resolved_hosts>0) {
-        struct sockaddr_storage* resolved = (struct sockaddr_storage*) &address->resolved_hosts[0];
+        volatile struct sockaddr_storage* resolved = &address->resolved_hosts[0];
         const uint16_t resolved_port = resolved->ss_family==AF_INET ?
                                        ((struct sockaddr_in*) (resolved))->sin_port
                                                                     : ((struct sockaddr_in6*) (resolved))->sin6_port;
@@ -174,7 +174,7 @@ int32_t BoltAddress_resolve(BoltAddress* address, int32_t* n_resolved, BoltLog* 
 int32_t BoltAddress_copy_resolved_host(BoltAddress* address, int32_t index, char* buffer,
         int32_t buffer_size)
 {
-    struct sockaddr_storage* resolved_host = (struct sockaddr_storage*) &address->resolved_hosts[index];
+    volatile struct sockaddr_storage* resolved_host = &address->resolved_hosts[index];
     int status = get_address_components(resolved_host, buffer, (int) buffer_size, NULL, 0);
     switch (status) {
     case 0:

--- a/src/seabolt/src/bolt/connector.c
+++ b/src/seabolt/src/bolt/connector.c
@@ -54,13 +54,13 @@ BoltConnector_create(BoltAddress* address, BoltValue* auth_token, struct BoltCon
 
     switch (connector->config->scheme) {
     case BOLT_SCHEME_DIRECT:
-        connector->pool_state = BoltDirectPool_create(address, connector->auth_token, connector->config);
+        connector->pool_state = BoltDirectPool_create(connector->address, connector->auth_token, connector->config);
         break;
     case BOLT_SCHEME_NEO4J:
-        connector->pool_state = BoltRoutingPool_create(address, connector->auth_token, connector->config);
+        connector->pool_state = BoltRoutingPool_create(connector->address, connector->auth_token, connector->config);
         break;
     case BOLT_SCHEME_DIRECT_UNPOOLED:
-        connector->pool_state = BoltNoPool_create(address, connector->auth_token, connector->config);
+        connector->pool_state = BoltNoPool_create(connector->address, connector->auth_token, connector->config);
         break;
     default:
         // TODO: Set some status

--- a/src/seabolt/src/bolt/name.c
+++ b/src/seabolt/src/bolt/name.c
@@ -19,7 +19,7 @@
 #include "bolt-private.h"
 #include "name.h"
 
-int get_address_components(const struct sockaddr_storage* address, char* host_buffer, int host_buffer_size,
+int get_address_components(volatile const struct sockaddr_storage* address, char* host_buffer, int host_buffer_size,
         char* port_buffer,
         int port_buffer_size)
 {

--- a/src/seabolt/src/bolt/name.h
+++ b/src/seabolt/src/bolt/name.h
@@ -19,7 +19,7 @@
 #ifndef SEABOLT_NAME_H
 #define SEABOLT_NAME_H
 
-int get_address_components(const struct sockaddr_storage* address, char* host_buffer, int host_buffer_size,
+int get_address_components(volatile const struct sockaddr_storage* address, char* host_buffer, int host_buffer_size,
         char* port_buffer, int port_buffer_size);
 
 #endif //SEABOLT_NAME_H

--- a/src/seabolt/src/bolt/routing-pool.h
+++ b/src/seabolt/src/bolt/routing-pool.h
@@ -23,13 +23,14 @@
 #include "address.h"
 #include "values.h"
 #include "atomic.h"
+#include "routing-table.h"
 
 struct BoltRoutingPool {
-    struct BoltAddress* address;
+    const struct BoltAddress* address;
     const struct BoltConfig* config;
     const struct BoltValue* auth_token;
 
-    struct RoutingTable* routing_table;
+    volatile RoutingTable* routing_table;
     int64_t readers_offset;
     int64_t writers_offset;
 
@@ -43,7 +44,7 @@ struct BoltRoutingPool {
 #define SIZE_OF_ROUTING_POOL_PTR sizeof(struct BoltRoutingConnectionPool*)
 
 struct BoltRoutingPool*
-BoltRoutingPool_create(struct BoltAddress* address, const struct BoltValue* auth_token,
+BoltRoutingPool_create(const struct BoltAddress* address, const struct BoltValue* auth_token,
         const struct BoltConfig* config);
 
 void BoltRoutingPool_destroy(struct BoltRoutingPool* pool);

--- a/src/seabolt/src/bolt/routing-table.h
+++ b/src/seabolt/src/bolt/routing-table.h
@@ -22,27 +22,27 @@
 #include "connector.h"
 #include "values.h"
 
-struct RoutingTable {
+typedef struct RoutingTable {
     int64_t expires;
     int64_t last_updated;
-    struct BoltAddressSet* readers;
-    struct BoltAddressSet* writers;
-    struct BoltAddressSet* routers;
-};
+    volatile BoltAddressSet* readers;
+    volatile BoltAddressSet* writers;
+    volatile BoltAddressSet* routers;
+} RoutingTable;
 
 #define SIZE_OF_ROUTING_TABLE sizeof(struct RoutingTable)
 #define SIZE_OF_ROUTING_TABLE_PTR sizeof(struct RoutingTable*)
 
-struct RoutingTable* RoutingTable_create();
+volatile RoutingTable* RoutingTable_create();
 
-void RoutingTable_destroy(struct RoutingTable* state);
+void RoutingTable_destroy(volatile RoutingTable* state);
 
-int RoutingTable_update(struct RoutingTable* state, struct BoltValue* response);
+int RoutingTable_update(volatile RoutingTable* state, struct BoltValue* response);
 
-int RoutingTable_is_expired(struct RoutingTable* state, BoltAccessMode mode);
+int RoutingTable_is_expired(volatile RoutingTable* state, BoltAccessMode mode);
 
-void RoutingTable_forget_server(struct RoutingTable* state, const struct BoltAddress* address);
+void RoutingTable_forget_server(volatile RoutingTable* state, const struct BoltAddress* address);
 
-void RoutingTable_forget_writer(struct RoutingTable* state, const struct BoltAddress* address);
+void RoutingTable_forget_writer(volatile RoutingTable* state, const struct BoltAddress* address);
 
 #endif //SEABOLT_ALL_ROUTING_TABLE_H

--- a/src/seabolt/tests/test-address-set.cpp
+++ b/src/seabolt/tests/test-address-set.cpp
@@ -28,7 +28,7 @@ SCENARIO("BoltAddressSet")
     struct BoltAddress* localhost7690 = BoltAddress_create("localhost", "7690");
 
     WHEN("constructed") {
-        struct BoltAddressSet* set = BoltAddressSet_create();
+        volatile BoltAddressSet* set = BoltAddressSet_create();
 
         THEN("it should have size = 0") {
             REQUIRE(set->size==0);
@@ -44,7 +44,7 @@ SCENARIO("BoltAddressSet")
     }
 
     GIVEN("a newly constructed BoltAddressSet") {
-        struct BoltAddressSet* set = BoltAddressSet_create();
+        volatile BoltAddressSet* set = BoltAddressSet_create();
 
         WHEN("BoltAddress[localhost,7687] is added") {
             BoltAddressSet_add(set, localhost7687);
@@ -95,7 +95,7 @@ SCENARIO("BoltAddressSet")
     }
 
     GIVEN("A BoltAddressSet with 3 addresses") {
-        struct BoltAddressSet* set = BoltAddressSet_create();
+        volatile BoltAddressSet* set = BoltAddressSet_create();
 
         BoltAddressSet_add(set, localhost7687);
         BoltAddressSet_add(set, localhost7688);
@@ -141,11 +141,11 @@ SCENARIO("BoltAddressSet")
     }
 
     GIVEN("Two different BoltAddressSets") {
-        struct BoltAddressSet* set1 = BoltAddressSet_create();
+        volatile BoltAddressSet* set1 = BoltAddressSet_create();
         REQUIRE(BoltAddressSet_add(set1, localhost7687)==0);
         REQUIRE(BoltAddressSet_add(set1, localhost7688)==1);
 
-        struct BoltAddressSet* set2 = BoltAddressSet_create();
+        volatile BoltAddressSet* set2 = BoltAddressSet_create();
         REQUIRE(BoltAddressSet_add(set2, localhost7689)==0);
 
         WHEN("set1 is updated from set2") {
@@ -170,10 +170,10 @@ SCENARIO("BoltAddressSet")
     }
 
     GIVEN("Two different BoltAddressSets") {
-        struct BoltAddressSet* set1 = BoltAddressSet_create();
+        volatile BoltAddressSet* set1 = BoltAddressSet_create();
         REQUIRE(BoltAddressSet_add(set1, localhost7689)==0);
 
-        struct BoltAddressSet* set2 = BoltAddressSet_create();
+        volatile BoltAddressSet* set2 = BoltAddressSet_create();
         REQUIRE(BoltAddressSet_add(set2, localhost7687)==0);
         REQUIRE(BoltAddressSet_add(set2, localhost7688)==1);
         REQUIRE(BoltAddressSet_add(set2, localhost7689)==2);


### PR DESCRIPTION
This PR adds `volatile` modifier to fields and function parameters so that concurrently modifiable and readable memory does not get cached and optimised by the compiler. It's an addendum to the previous PR #72 (specifically commit 84677e9f4277a1f3e2bb9c9bf0a39865f4188388).