### PR TITLE
fix MacOS 10.15.2 Xcode Version 11.3 (11C29) make_release.sh failed

### DIFF
--- a/src/seabolt-cli/src/main.c
+++ b/src/seabolt-cli/src/main.c
@@ -39,6 +39,27 @@
 
 #define UNUSED(x) (void)(x)
 
+#ifdef __APPLE__
+#include <mach/clock.h>
+#include <mach/mach.h>
+
+#ifndef TIME_UTC
+#define TIME_UTC 0
+
+void timespec_get(struct timespec *ts, int type)
+{
+    UNUSED(type);
+    clock_serv_t cclock;
+    mach_timespec_t mts;
+    host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
+    clock_get_time(cclock, &mts);
+    mach_port_deallocate(mach_task_self(), cclock);
+    ts->tv_sec = mts.tv_sec;
+    ts->tv_nsec = mts.tv_nsec;
+}
+#endif
+#endif
+
 enum Command
 {
     CMD_NONE,

--- a/src/seabolt-cli/src/main.c
+++ b/src/seabolt-cli/src/main.c
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-
 #include <memory.h>
 #include <stdlib.h>
 #include <string.h>
@@ -35,31 +34,13 @@
 #endif // WIN32
 
 #if defined(_WIN32) && _MSC_VER
-#pragma  warning(disable:4204)
+#pragma warning(disable : 4204)
 #endif
 
 #define UNUSED(x) (void)(x)
 
-#ifdef __APPLE__
-#include <mach/clock.h>
-#include <mach/mach.h>
-
-#define TIME_UTC 0
-
-void timespec_get(struct timespec *ts, int type)
+enum Command
 {
-    UNUSED(type);
-    clock_serv_t cclock;
-    mach_timespec_t mts;
-    host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
-    clock_get_time(cclock, &mts);
-    mach_port_deallocate(mach_task_self(), cclock);
-    ts->tv_sec = mts.tv_sec;
-    ts->tv_nsec = mts.tv_nsec;
-}
-#endif
-
-enum Command {
     CMD_NONE,
     CMD_HELP,
     CMD_DEBUG,
@@ -67,11 +48,13 @@ enum Command {
     CMD_RUN,
 };
 
-struct Application {
-    struct BoltConnector* connector;
-    struct BoltConnection* connection;
+struct Application
+{
+    struct BoltConnector *connector;
+    struct BoltConnection *connection;
     BoltAccessMode access_mode;
-    struct {
+    struct
+    {
         struct timespec connect_time;
         struct timespec init_time;
     } stats;
@@ -80,38 +63,40 @@ struct Application {
     enum Command command;
     int first_arg_index;
     int argc;
-    char** argv;
+    char **argv;
 };
 
-const char* getenv_or_default(const char* name, const char* default_value)
+const char *getenv_or_default(const char *name, const char *default_value)
 {
-    const char* value = getenv(name);
-    return (value==NULL) ? default_value : value;
+    const char *value = getenv(name);
+    return (value == NULL) ? default_value : value;
 }
 
-void timespec_diff(struct timespec* t, struct timespec* t0, struct timespec* t1)
+void timespec_diff(struct timespec *t, struct timespec *t0, struct timespec *t1)
 {
-    t->tv_sec = t0->tv_sec-t1->tv_sec;
-    t->tv_nsec = t0->tv_nsec-t1->tv_nsec;
-    while (t->tv_nsec>=1000000000) {
+    t->tv_sec = t0->tv_sec - t1->tv_sec;
+    t->tv_nsec = t0->tv_nsec - t1->tv_nsec;
+    while (t->tv_nsec >= 1000000000)
+    {
         t->tv_sec += 1;
         t->tv_nsec -= 1000000000;
     }
-    while (t->tv_nsec<0) {
+    while (t->tv_nsec < 0)
+    {
         t->tv_sec -= 1;
         t->tv_nsec += 1000000000;
     }
 }
 
-void log_to_stderr(void* state, const char* message)
+void log_to_stderr(void *state, const char *message)
 {
     UNUSED(state);
     fprintf(stderr, "%s\n", message);
 }
 
-struct BoltLog* create_logger(int enabled)
+struct BoltLog *create_logger(int enabled)
 {
-    struct BoltLog* log = BoltLog_create(0);
+    struct BoltLog *log = BoltLog_create(0);
     BoltLog_set_debug_func(log, enabled ? log_to_stderr : NULL);
     BoltLog_set_warning_func(log, enabled ? log_to_stderr : NULL);
     BoltLog_set_info_func(log, enabled ? log_to_stderr : NULL);
@@ -136,33 +121,34 @@ void app_help()
     fprintf(stderr, "  %-16s: Password\n", "BOLT_PASSWORD");
 }
 
-struct Application* app_create(int argc, char** argv)
+struct Application *app_create(int argc, char **argv)
 {
-    const char* BOLT_CONFIG_ROUTING = getenv_or_default("BOLT_ROUTING", "0");
-    const char* BOLT_CONFIG_ACCESS_MODE = getenv_or_default("BOLT_ACCESS_MODE", "WRITE");
-    const char* BOLT_CONFIG_SECURE = getenv_or_default("BOLT_SECURE", "1");
-    const char* BOLT_CONFIG_HOST = getenv_or_default("BOLT_HOST", "localhost");
-    const char* BOLT_CONFIG_PORT = getenv_or_default("BOLT_PORT", "7687");
-    const char* BOLT_CONFIG_USER = getenv_or_default("BOLT_USER", "neo4j");
-    const char* BOLT_CONFIG_PASSWORD = getenv("BOLT_PASSWORD");
+    const char *BOLT_CONFIG_ROUTING = getenv_or_default("BOLT_ROUTING", "0");
+    const char *BOLT_CONFIG_ACCESS_MODE = getenv_or_default("BOLT_ACCESS_MODE", "WRITE");
+    const char *BOLT_CONFIG_SECURE = getenv_or_default("BOLT_SECURE", "1");
+    const char *BOLT_CONFIG_HOST = getenv_or_default("BOLT_HOST", "localhost");
+    const char *BOLT_CONFIG_PORT = getenv_or_default("BOLT_PORT", "7687");
+    const char *BOLT_CONFIG_USER = getenv_or_default("BOLT_USER", "neo4j");
+    const char *BOLT_CONFIG_PASSWORD = getenv("BOLT_PASSWORD");
 
     // Verify environment variables
-    int valid_config = strcmp(BOLT_CONFIG_ROUTING, "")!=0 && strcmp(BOLT_CONFIG_ACCESS_MODE, "")!=0
-            && strcmp(BOLT_CONFIG_SECURE, "")!=0 && strcmp(BOLT_CONFIG_HOST, "")!=0 && strcmp(BOLT_CONFIG_PORT, "")!=0;
-    if (!valid_config) {
+    int valid_config = strcmp(BOLT_CONFIG_ROUTING, "") != 0 && strcmp(BOLT_CONFIG_ACCESS_MODE, "") != 0 && strcmp(BOLT_CONFIG_SECURE, "") != 0 && strcmp(BOLT_CONFIG_HOST, "") != 0 && strcmp(BOLT_CONFIG_PORT, "") != 0;
+    if (!valid_config)
+    {
         app_help();
         exit(EXIT_FAILURE);
     }
 
     // Verify password is provided when user is set
-    if (strcmp(BOLT_CONFIG_USER, "")!=0 && (BOLT_CONFIG_PASSWORD==NULL || strcmp(BOLT_CONFIG_PASSWORD, "")==0)) {
+    if (strcmp(BOLT_CONFIG_USER, "") != 0 && (BOLT_CONFIG_PASSWORD == NULL || strcmp(BOLT_CONFIG_PASSWORD, "") == 0))
+    {
         app_help();
         exit(EXIT_FAILURE);
     }
 
-    struct Application* app = malloc(sizeof(struct Application));
+    struct Application *app = malloc(sizeof(struct Application));
 
-    app->access_mode = (strcmp(BOLT_CONFIG_ACCESS_MODE, "WRITE")==0 ? BOLT_ACCESS_MODE_WRITE : BOLT_ACCESS_MODE_READ);
+    app->access_mode = (strcmp(BOLT_CONFIG_ACCESS_MODE, "WRITE") == 0 ? BOLT_ACCESS_MODE_WRITE : BOLT_ACCESS_MODE_READ);
     app->with_allocation_report = 0;
     app->with_header = 0;
     app->command = CMD_NONE;
@@ -170,65 +156,79 @@ struct Application* app_create(int argc, char** argv)
     app->argv = argv;
     app->argc = argc;
 
-    for (int i = 1; i<argc; i++) {
-        const char* arg = argv[i];
-        if (strlen(arg)>=1 && arg[0]=='-') {
+    for (int i = 1; i < argc; i++)
+    {
+        const char *arg = argv[i];
+        if (strlen(arg) >= 1 && arg[0] == '-')
+        {
             // option
-            if (strcmp(arg, "-a")==0) {
+            if (strcmp(arg, "-a") == 0)
+            {
                 app->with_allocation_report = 1;
             }
-            else if (strcmp(arg, "-h")==0) {
+            else if (strcmp(arg, "-h") == 0)
+            {
                 app->with_header = 1;
             }
-            else {
+            else
+            {
                 fprintf(stderr, "Unknown option %s\n", arg);
                 exit(EXIT_FAILURE);
             }
         }
-        else if (app->command==CMD_NONE) {
+        else if (app->command == CMD_NONE)
+        {
             // command
-            if (strcmp(arg, "help")==0) {
+            if (strcmp(arg, "help") == 0)
+            {
                 app->command = CMD_HELP;
             }
-            else if (strcmp(arg, "debug")==0) {
+            else if (strcmp(arg, "debug") == 0)
+            {
                 app->command = CMD_DEBUG;
             }
-            else if (strcmp(arg, "perf")==0) {
+            else if (strcmp(arg, "perf") == 0)
+            {
                 app->command = CMD_PERF;
             }
-            else if (strcmp(arg, "run")==0) {
+            else if (strcmp(arg, "run") == 0)
+            {
                 app->command = CMD_RUN;
             }
-            else {
+            else
+            {
                 fprintf(stderr, "Unknown command %s\n", arg);
                 exit(EXIT_FAILURE);
             }
         }
-        else {
+        else
+        {
             // argument
             app->first_arg_index = i;
             break;
         }
     }
 
-    BoltLog* log = create_logger(app->command==CMD_DEBUG);
-    BoltConfig* config = BoltConfig_create();
-    BoltConfig_set_scheme(config, (strcmp(BOLT_CONFIG_ROUTING, "1")==0) ? BOLT_SCHEME_NEO4J : BOLT_SCHEME_DIRECT);
+    BoltLog *log = create_logger(app->command == CMD_DEBUG);
+    BoltConfig *config = BoltConfig_create();
+    BoltConfig_set_scheme(config, (strcmp(BOLT_CONFIG_ROUTING, "1") == 0) ? BOLT_SCHEME_NEO4J : BOLT_SCHEME_DIRECT);
     BoltConfig_set_transport(config,
-            (strcmp(BOLT_CONFIG_SECURE, "1")==0) ? BOLT_TRANSPORT_ENCRYPTED : BOLT_TRANSPORT_PLAINTEXT);
+                             (strcmp(BOLT_CONFIG_SECURE, "1") == 0) ? BOLT_TRANSPORT_ENCRYPTED : BOLT_TRANSPORT_PLAINTEXT);
     BoltConfig_set_user_agent(config, "seabolt/" SEABOLT_VERSION);
     BoltConfig_set_max_pool_size(config, 10);
     BoltConfig_set_log(config, log);
 
-    struct BoltValue* auth_token = NULL;
-    if (strcmp(BOLT_CONFIG_USER, "")!=0) {
+    struct BoltValue *auth_token = NULL;
+    if (strcmp(BOLT_CONFIG_USER, "") != 0)
+    {
         auth_token = BoltAuth_basic(BOLT_CONFIG_USER, BOLT_CONFIG_PASSWORD, NULL);
     }
-    else {
+    else
+    {
         auth_token = BoltAuth_none();
     }
 
-    struct BoltAddress* address = BoltAddress_create((char*) BOLT_CONFIG_HOST, (char*) BOLT_CONFIG_PORT);
+    struct BoltAddress *address = BoltAddress_create((char *)BOLT_CONFIG_HOST, (char *)BOLT_CONFIG_PORT);
 
     app->connector = BoltConnector_create(address, auth_token, config);
 
@@ -240,19 +240,20 @@ struct Application* app_create(int argc, char** argv)
     return app;
 }
 
-void app_destroy(struct Application* app)
+void app_destroy(struct Application *app)
 {
     BoltConnector_destroy(app->connector);
     free(app);
 }
 
-void app_connect(struct Application* app)
+void app_connect(struct Application *app)
 {
     struct timespec t[2];
     BoltTime_get_time(&t[0]);
-    BoltStatus* status = BoltStatus_create();
-    BoltConnection* connection = BoltConnector_acquire(app->connector, app->access_mode, status);
-    if (connection==NULL) {
+    BoltStatus *status = BoltStatus_create();
+    BoltConnection *connection = BoltConnector_acquire(app->connector, app->access_mode, status);
+    if (connection == NULL)
+    {
         fprintf(stderr, "FATAL: Failed to connect\n");
         app_destroy(app);
         exit(EXIT_FAILURE);
@@ -263,15 +264,15 @@ void app_connect(struct Application* app)
     timespec_diff(&app->stats.connect_time, &t[1], &t[0]);
 }
 
-int app_debug(struct Application* app, const char* cypher)
+int app_debug(struct Application *app, const char *cypher)
 {
     struct timespec t[7];
 
-    BoltTime_get_time(&t[1]);    // Checkpoint 1 - right at the start
+    BoltTime_get_time(&t[1]); // Checkpoint 1 - right at the start
 
     app_connect(app);
 
-    BoltTime_get_time(&t[2]);    // Checkpoint 2 - after handshake and initialisation
+    BoltTime_get_time(&t[2]); // Checkpoint 2 - after handshake and initialisation
 
     //BoltConnection_load_bookmark(bolt->connection, "tx:1234");
     BoltConnection_load_begin_request(app->connection);
@@ -285,25 +286,26 @@ int app_debug(struct Application* app, const char* cypher)
 
     BoltConnection_send(app->connection);
 
-    BoltTime_get_time(&t[3]);    // Checkpoint 3 - after query transmission
+    BoltTime_get_time(&t[3]); // Checkpoint 3 - after query transmission
 
     long record_count = 0;
 
     BoltConnection_fetch_summary(app->connection, run);
 
-    BoltTime_get_time(&t[4]);    // Checkpoint 4 - receipt of header
+    BoltTime_get_time(&t[4]); // Checkpoint 4 - receipt of header
 
-    while (BoltConnection_fetch(app->connection, pull)) {
+    while (BoltConnection_fetch(app->connection, pull))
+    {
         record_count += 1;
     }
 
     BoltConnection_fetch_summary(app->connection, commit);
 
-    BoltTime_get_time(&t[5]);    // Checkpoint 5 - receipt of footer
+    BoltTime_get_time(&t[5]); // Checkpoint 5 - receipt of footer
 
     BoltConnector_release(app->connector, app->connection);
 
-    BoltTime_get_time(&t[6]);    // Checkpoint 6 - after close
+    BoltTime_get_time(&t[6]); // Checkpoint 6 - after close
 
     ///////////////////////////////////////////////////////////////////
 
@@ -312,30 +314,30 @@ int app_debug(struct Application* app, const char* cypher)
     fprintf(stderr, "=====================================\n");
 
     timespec_diff(&t[0], &t[2], &t[1]);
-    fprintf(stderr, "initialisation       : %lds %09ldns\n", (long) t[0].tv_sec, t[0].tv_nsec);
+    fprintf(stderr, "initialisation       : %lds %09ldns\n", (long)t[0].tv_sec, t[0].tv_nsec);
 
     timespec_diff(&t[0], &t[3], &t[2]);
-    fprintf(stderr, "query transmission   : %lds %09ldns\n", (long) t[0].tv_sec, t[0].tv_nsec);
+    fprintf(stderr, "query transmission   : %lds %09ldns\n", (long)t[0].tv_sec, t[0].tv_nsec);
 
     timespec_diff(&t[0], &t[4], &t[3]);
-    fprintf(stderr, "query processing     : %lds %09ldns\n", (long) t[0].tv_sec, t[0].tv_nsec);
+    fprintf(stderr, "query processing     : %lds %09ldns\n", (long)t[0].tv_sec, t[0].tv_nsec);
 
     timespec_diff(&t[0], &t[5], &t[4]);
-    fprintf(stderr, "result processing    : %lds %09ldns\n", (long) t[0].tv_sec, t[0].tv_nsec);
+    fprintf(stderr, "result processing    : %lds %09ldns\n", (long)t[0].tv_sec, t[0].tv_nsec);
 
     timespec_diff(&t[0], &t[6], &t[5]);
-    fprintf(stderr, "shutdown             : %lds %09ldns\n", (long) t[0].tv_sec, t[0].tv_nsec);
+    fprintf(stderr, "shutdown             : %lds %09ldns\n", (long)t[0].tv_sec, t[0].tv_nsec);
 
     timespec_diff(&t[0], &t[6], &t[1]);
     fprintf(stderr, "=====================================\n");
-    fprintf(stderr, "TOTAL                : %lds %09ldns\n", (long) t[0].tv_sec, t[0].tv_nsec);
+    fprintf(stderr, "TOTAL                : %lds %09ldns\n", (long)t[0].tv_sec, t[0].tv_nsec);
 
     BoltConnector_release(app->connector, app->connection);
 
     return 0;
 }
 
-int app_run(struct Application* app, const char* cypher)
+int app_run(struct Application *app, const char *cypher)
 {
     app_connect(app);
 
@@ -349,13 +351,17 @@ int app_run(struct Application* app, const char* cypher)
 
     BoltConnection_fetch_summary(app->connection, run);
     char string_buffer[4096];
-    if (app->with_header) {
-        const struct BoltValue* fields = BoltConnection_field_names(app->connection);
-        for (int i = 0; i<BoltValue_size(fields); i++) {
-            if (i>0) {
+    if (app->with_header)
+    {
+        const struct BoltValue *fields = BoltConnection_field_names(app->connection);
+        for (int i = 0; i < BoltValue_size(fields); i++)
+        {
+            if (i > 0)
+            {
                 putc('\t', stdout);
             }
-            if (BoltValue_to_string(BoltList_value(fields, i), string_buffer, 4096, app->connection)>4096) {
+            if (BoltValue_to_string(BoltList_value(fields, i), string_buffer, 4096, app->connection) > 4096)
+            {
                 string_buffer[4095] = 0;
             }
             fprintf(stdout, "%s", string_buffer);
@@ -363,14 +369,18 @@ int app_run(struct Application* app, const char* cypher)
         putc('\n', stdout);
     }
 
-    while (BoltConnection_fetch(app->connection, pull)) {
-        const struct BoltValue* field_values = BoltConnection_field_values(app->connection);
-        for (int i = 0; i<BoltValue_size(field_values); i++) {
-            struct BoltValue* value = BoltList_value(field_values, i);
-            if (i>0) {
+    while (BoltConnection_fetch(app->connection, pull))
+    {
+        const struct BoltValue *field_values = BoltConnection_field_values(app->connection);
+        for (int i = 0; i < BoltValue_size(field_values); i++)
+        {
+            struct BoltValue *value = BoltList_value(field_values, i);
+            if (i > 0)
+            {
                 putc('\t', stdout);
             }
-            if (BoltValue_to_string(value, string_buffer, 4096, app->connection)>4096) {
+            if (BoltValue_to_string(value, string_buffer, 4096, app->connection) > 4096)
+            {
                 string_buffer[4095] = 0;
             }
             fprintf(stdout, "%s", string_buffer);
@@ -383,7 +393,7 @@ int app_run(struct Application* app, const char* cypher)
     return 0;
 }
 
-long run_fetch(const struct Application* app, const char* cypher)
+long run_fetch(const struct Application *app, const char *cypher)
 {
     long record_count = 0;
     BoltConnection_load_begin_request(app->connection);
@@ -399,7 +409,8 @@ long run_fetch(const struct Application* app, const char* cypher)
 
     BoltConnection_fetch_summary(app->connection, run);
 
-    while (BoltConnection_fetch(app->connection, pull)) {
+    while (BoltConnection_fetch(app->connection, pull))
+    {
         record_count += 1;
     }
 
@@ -407,22 +418,24 @@ long run_fetch(const struct Application* app, const char* cypher)
     return record_count;
 }
 
-int app_perf(struct Application* app, long warmup_times, long actual_times, const char* cypher)
+int app_perf(struct Application *app, long warmup_times, long actual_times, const char *cypher)
 {
     struct timespec t[3];
 
     app_connect(app);
 
-    for (int i = 0; i<warmup_times; i++) {
+    for (int i = 0; i < warmup_times; i++)
+    {
         run_fetch(app, cypher);
     }
 
-    BoltTime_get_time(&t[1]);    // Checkpoint 1 - before run
+    BoltTime_get_time(&t[1]); // Checkpoint 1 - before run
     long record_count = 0;
-    for (int i = 0; i<actual_times; i++) {
+    for (int i = 0; i < actual_times; i++)
+    {
         record_count += run_fetch(app, cypher);
     }
-    BoltTime_get_time(&t[2]);    // Checkpoint 2 - after run
+    BoltTime_get_time(&t[2]); // Checkpoint 2 - after run
 
     BoltConnector_release(app->connector, app->connection);
 
@@ -433,18 +446,19 @@ int app_perf(struct Application* app, long warmup_times, long actual_times, cons
 
     timespec_diff(&t[0], &t[2], &t[1]);
     fprintf(stderr, "=====================================\n");
-    fprintf(stderr, "TOTAL TIME           : %lds %09ldns\n", (long) t[0].tv_sec, t[0].tv_nsec);
+    fprintf(stderr, "TOTAL TIME           : %lds %09ldns\n", (long)t[0].tv_sec, t[0].tv_nsec);
 
     return 0;
 }
 
-int main(int argc, char* argv[])
+int main(int argc, char *argv[])
 {
     Bolt_startup();
 
-    struct Application* app = app_create(argc, argv);
+    struct Application *app = app_create(argc, argv);
 
-    switch (app->command) {
+    switch (app->command)
+    {
     case CMD_NONE:
     case CMD_HELP:
         app_help();
@@ -452,11 +466,12 @@ int main(int argc, char* argv[])
     case CMD_DEBUG:
         app_debug(app, argv[app->first_arg_index]);
         break;
-    case CMD_PERF: {
-        char* end;
-        app_perf(app, strtol(argv[app->first_arg_index], &end, 10),      // warmup_times
-                strtol(argv[app->first_arg_index+1], &end, 10),  // actual_times
-                argv[app->first_arg_index+2]);                   // cypher
+    case CMD_PERF:
+    {
+        char *end;
+        app_perf(app, strtol(argv[app->first_arg_index], &end, 10), // warmup_times
+                 strtol(argv[app->first_arg_index + 1], &end, 10),  // actual_times
+                 argv[app->first_arg_index + 2]);                   // cypher
         break;
     }
     case CMD_RUN:
@@ -468,18 +483,21 @@ int main(int argc, char* argv[])
 
     Bolt_shutdown();
 
-    if (with_allocation_report) {
+    if (with_allocation_report)
+    {
         fprintf(stderr, "=====================================\n");
-        fprintf(stderr, "current allocation   : %" PRIu64 " bytes\n", (int64_t) BoltStat_memory_allocation_current());
-        fprintf(stderr, "peak allocation      : %" PRId64 " bytes\n", (int64_t) BoltStat_memory_allocation_peak());
+        fprintf(stderr, "current allocation   : %" PRIu64 " bytes\n", (int64_t)BoltStat_memory_allocation_current());
+        fprintf(stderr, "peak allocation      : %" PRId64 " bytes\n", (int64_t)BoltStat_memory_allocation_peak());
         fprintf(stderr, "allocation events    : %" PRId64 "\n", BoltStat_memory_allocation_events());
         fprintf(stderr, "=====================================\n");
     }
 
-    if (BoltStat_memory_allocation_current()==0) {
+    if (BoltStat_memory_allocation_current() == 0)
+    {
         return EXIT_SUCCESS;
     }
-    else {
+    else
+    {
         fprintf(stderr, "MEMORY LEAK!\n");
         return EXIT_FAILURE;
     }


### PR DESCRIPTION
When :MacOS 10.15.2 Xcode Version 11.3 (11C29) ,use make_release.sh will failed:
```
jason@mac:~/githubcode/seabolt|1.7⚡
⇒  ./make_release.sh
-- The C compiler identification is AppleClang 11.0.0.11000033
-- The CXX compiler identification is AppleClang 11.0.0.11000033
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Building seabolt: 1.7.4-dev
-- Looking for unistd.h
-- Looking for unistd.h - found
-- Check if the system is big endian
-- Searching 16 bit integer
-- Looking for sys/types.h
-- Looking for sys/types.h - found
-- Looking for stdint.h
-- Looking for stdint.h - found
-- Looking for stddef.h
-- Looking for stddef.h - found
-- Check size of unsigned short
-- Check size of unsigned short - done
-- Using unsigned short
-- Check if the system is big endian - little endian
-- Building seabolt with TLS support
-- Using OPENSSL for TLS
-- Looking for timespec_get
-- Looking for timespec_get - found
-- Found OpenSSL: /usr/local/opt/openssl/lib/libcrypto.dylib (found version "1.1.1d")
-- Discovered OpenSSL shared libraries: /usr/local/opt/openssl/lib/libssl.dylib;/usr/local/opt/openssl/lib/libcrypto.dylib
-- Found OpenSSL: /usr/local/opt/openssl/lib/libcrypto.a (found version "1.1.1d")
-- Discovered OpenSSL static libraries: /usr/local/opt/openssl/lib/libssl.a;/usr/local/opt/openssl/lib/libcrypto.a
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY - Success
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY - Success
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR - Success
-- CPack generators: TGZ
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/xuyong/githubcode/seabolt/build
Scanning dependencies of target write_version_info
-- Using Git hash from git command: 875643c
[  0%] Built target write_version_info
Scanning dependencies of target seabolt-static
[  1%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/address-resolver.c.o
[  2%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/address-set.c.o
[  3%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/address.c.o
[  4%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/auth.c.o
[  5%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/buffering.c.o
[  6%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/config.c.o
[  7%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/connection.c.o
[  8%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/connector.c.o
[ 10%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/communication.c.o
[ 11%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/communication-plain.c.o
[ 12%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/communication-mock.c.o
[ 13%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/direct-pool.c.o
[ 14%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/error.c.o
[ 15%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/lifecycle.c.o
[ 16%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/log.c.o
[ 17%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/mem.c.o
[ 18%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/name.c.o
[ 20%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/no-pool.c.o
[ 21%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/packstream.c.o
[ 22%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/protocol.c.o
[ 23%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/routing-pool.c.o
[ 24%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/routing-table.c.o
[ 25%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/stats.c.o
[ 26%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/status.c.o
[ 27%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/string-builder.c.o
[ 28%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/time.c.o
[ 30%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/v1.c.o
[ 31%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/v2.c.o
[ 32%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/v3.c.o
[ 33%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/values.c.o
[ 34%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/sync-pthread.c.o
[ 35%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/communication-plain-posix.c.o
[ 36%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/time-timespec.c.o
[ 37%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/atomic-macos.c.o
[ 38%] Building C object CMakeFiles/seabolt-static.dir/src/seabolt/src/bolt/communication-secure-openssl.c.o
[ 40%] Linking C static library lib/libseabolt17.a
-- Passed /usr/local/opt/openssl/lib/libssl.a;/usr/local/opt/openssl/lib/libcrypto.a
-- Processed /usr/local/opt/openssl/lib/libssl.a /usr/local/opt/openssl/lib/libcrypto.a
[ 40%] Built target seabolt-static
Scanning dependencies of target seabolt-test
[ 41%] Building CXX object CMakeFiles/seabolt-test.dir/src/seabolt/tests/main.cpp.o
[ 42%] Building CXX object CMakeFiles/seabolt-test.dir/src/seabolt/tests/seabolt.cpp.o
[ 43%] Building CXX object CMakeFiles/seabolt-test.dir/src/seabolt/tests/test-address-set.cpp.o
[ 44%] Building CXX object CMakeFiles/seabolt-test.dir/src/seabolt/tests/test-addressing.cpp.o
[ 45%] Building CXX object CMakeFiles/seabolt-test.dir/src/seabolt/tests/test-chunking-v1.cpp.o
[ 46%] Building CXX object CMakeFiles/seabolt-test.dir/src/seabolt/tests/test-communication.cpp.o
[ 47%] Building CXX object CMakeFiles/seabolt-test.dir/src/seabolt/tests/test-connection.cpp.o
[ 48%] Building CXX object CMakeFiles/seabolt-test.dir/src/seabolt/tests/test-direct.cpp.o
[ 50%] Building CXX object CMakeFiles/seabolt-test.dir/src/seabolt/tests/test-pooling.cpp.o
[ 51%] Building CXX object CMakeFiles/seabolt-test.dir/src/seabolt/tests/test-values.cpp.o
[ 52%] Building CXX object CMakeFiles/seabolt-test.dir/src/seabolt/tests/test-warden.cpp.o
[ 53%] Building CXX object CMakeFiles/seabolt-test.dir/src/seabolt/tests/test-string-builder.cpp.o
[ 54%] Building CXX object CMakeFiles/seabolt-test.dir/src/seabolt/tests/test-direct-pool.cpp.o
[ 55%] Building CXX object CMakeFiles/seabolt-test.dir/src/seabolt/tests/test-v3.cpp.o
[ 56%] Building CXX object CMakeFiles/seabolt-test.dir/src/seabolt/tests/utils/test-context.cpp.o
[ 57%] Linking CXX executable bin/seabolt-test
[ 57%] Built target seabolt-test
Scanning dependencies of target seabolt-shared
[ 58%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/address-resolver.c.o
[ 60%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/address-set.c.o
[ 61%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/address.c.o
[ 62%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/auth.c.o
[ 63%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/buffering.c.o
[ 64%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/config.c.o
[ 65%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/connection.c.o
[ 66%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/connector.c.o
[ 67%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/communication.c.o
[ 68%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/communication-plain.c.o
[ 70%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/communication-mock.c.o
[ 71%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/direct-pool.c.o
[ 72%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/error.c.o
[ 73%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/lifecycle.c.o
[ 74%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/log.c.o
[ 75%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/mem.c.o
[ 76%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/name.c.o
[ 77%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/no-pool.c.o
[ 78%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/packstream.c.o
[ 80%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/protocol.c.o
[ 81%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/routing-pool.c.o
[ 82%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/routing-table.c.o
[ 83%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/stats.c.o
[ 84%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/status.c.o
[ 85%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/string-builder.c.o
[ 86%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/time.c.o
[ 87%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/v1.c.o
[ 88%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/v2.c.o
[ 90%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/v3.c.o
[ 91%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/values.c.o
[ 92%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/sync-pthread.c.o
[ 93%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/communication-plain-posix.c.o
[ 94%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/time-timespec.c.o
[ 95%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/atomic-macos.c.o
[ 96%] Building C object CMakeFiles/seabolt-shared.dir/src/seabolt/src/bolt/communication-secure-openssl.c.o
[ 97%] Linking C shared library lib/libseabolt17.dylib
-- Passed
-- Processed
[ 97%] Built target seabolt-shared
Scanning dependencies of target seabolt-cli
[ 98%] Building C object CMakeFiles/seabolt-cli.dir/src/seabolt-cli/src/main.c.o
/Users/xuyong/githubcode/seabolt/src/seabolt-cli/src/main.c:46:9: error: 'TIME_UTC' macro redefined [-Werror,-Wmacro-redefined]
#define TIME_UTC 0
        ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/include/time.h:197:9: note: previous definition is here
#define TIME_UTC        1       /* time elapsed since epoch */
        ^
/Users/xuyong/githubcode/seabolt/src/seabolt-cli/src/main.c:48:6: error: conflicting types for 'timespec_get'
void timespec_get(struct timespec *ts, int type)
     ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/include/time.h:199:5: note: previous declaration is here
int timespec_get(struct timespec *ts, int base);
    ^
2 errors generated.
make[2]: *** [CMakeFiles/seabolt-cli.dir/src/seabolt-cli/src/main.c.o] Error 1
make[1]: *** [CMakeFiles/seabolt-cli.dir/all] Error 2
make: *** [all] Error 2
```
The macro already define in sdk file ：
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/time.h
```
#define TIME_UTC	1	/* time elapsed since epoch */
__API_AVAILABLE(macosx(10.15), ios(13.0), tvos(13.0), watchos(6.0))
int timespec_get(struct timespec *ts, int base);
#endif
```
so, remove it will fine.