### PR TITLE
Add more packaging support

### DIFF
--- a/CMakeCPack.cmake
+++ b/CMakeCPack.cmake
@@ -47,7 +47,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
 endif ()
 
 if (UNIX)
-    if (OS_ID_LIKE MATCHES "debian")
+    if (OS_ID MATCHES "debian" OR OS_ID_LIKE MATCHES "debian")
         list(APPEND CPACK_GENERATOR "DEB")
         set(CPACK_DEBIAN_PACKAGE_NAME "${SEABOLT_NAME}")
         set(CPACK_DEBIAN_PACKAGE_VERSION "${PROJECT_VERSION}")

--- a/ci/linux/Dockerfile.package-alpine-3.10
+++ b/ci/linux/Dockerfile.package-alpine-3.10
@@ -1,0 +1,11 @@
+FROM alpine:3.10
+RUN apk add --no-cache ca-certificates cmake make g++ openssl-dev git
+ARG SEABOLT_VERSION
+ARG SEABOLT_VERSION_HASH
+ENV SEABOLT_VERSION=$SEABOLT_VERSION
+ENV SEABOLT_VERSION_HASH=$SEABOLT_VERSION_HASH
+ADD . /tmp/seabolt
+WORKDIR /tmp/seabolt/build-docker
+RUN cmake -D CMAKE_BUILD_TYPE=Release /tmp/seabolt \
+    && cmake --build . --target package
+CMD tar -czf - dist-package/seabolt*

--- a/ci/linux/Dockerfile.package-alpine-3.11
+++ b/ci/linux/Dockerfile.package-alpine-3.11
@@ -1,0 +1,11 @@
+FROM alpine:3.11
+RUN apk add --no-cache ca-certificates cmake make g++ openssl-dev openssl-libs-static git
+ARG SEABOLT_VERSION
+ARG SEABOLT_VERSION_HASH
+ENV SEABOLT_VERSION=$SEABOLT_VERSION
+ENV SEABOLT_VERSION_HASH=$SEABOLT_VERSION_HASH
+ADD . /tmp/seabolt
+WORKDIR /tmp/seabolt/build-docker
+RUN cmake -D CMAKE_BUILD_TYPE=Release /tmp/seabolt \
+    && cmake --build . --target package
+CMD tar -czf - dist-package/seabolt*

--- a/ci/linux/Dockerfile.package-debian-buster
+++ b/ci/linux/Dockerfile.package-debian-buster
@@ -1,0 +1,14 @@
+FROM debian:buster
+RUN apt-get update \
+        && apt-get install -y ca-certificates make g++ libssl-dev git wget pkg-config dpkg-dev file \
+        && (mkdir -p /cmake && wget --no-verbose --output-document=- https://cmake.org/files/v3.12/cmake-3.12.3-Linux-x86_64.tar.gz | tar xvz -C /cmake --strip 1) \
+        && rm -rf /var/lib/apt/lists/*
+ARG SEABOLT_VERSION
+ARG SEABOLT_VERSION_HASH
+ENV SEABOLT_VERSION=$SEABOLT_VERSION
+ENV SEABOLT_VERSION_HASH=$SEABOLT_VERSION_HASH
+ADD . /tmp/seabolt
+WORKDIR /tmp/seabolt/build-docker
+RUN /cmake/bin/cmake -D CMAKE_BUILD_TYPE=Release /tmp/seabolt \
+    && /cmake/bin/cmake --build . --target package
+CMD tar -czf - dist-package/seabolt*

--- a/ci/linux/Dockerfile.package-debian-stretch
+++ b/ci/linux/Dockerfile.package-debian-stretch
@@ -1,0 +1,14 @@
+FROM debian:stretch
+RUN apt-get update \
+        && apt-get install -y ca-certificates make g++ libssl-dev git wget pkg-config dpkg-dev file \
+        && (mkdir -p /cmake && wget --no-verbose --output-document=- https://cmake.org/files/v3.12/cmake-3.12.3-Linux-x86_64.tar.gz | tar xvz -C /cmake --strip 1) \
+        && rm -rf /var/lib/apt/lists/*
+ARG SEABOLT_VERSION
+ARG SEABOLT_VERSION_HASH
+ENV SEABOLT_VERSION=$SEABOLT_VERSION
+ENV SEABOLT_VERSION_HASH=$SEABOLT_VERSION_HASH
+ADD . /tmp/seabolt
+WORKDIR /tmp/seabolt/build-docker
+RUN /cmake/bin/cmake -D CMAKE_BUILD_TYPE=Release /tmp/seabolt \
+    && /cmake/bin/cmake --build . --target package
+CMD tar -czf - dist-package/seabolt*

--- a/ci/linux/Dockerfile.package-ubuntu-19.10
+++ b/ci/linux/Dockerfile.package-ubuntu-19.10
@@ -1,0 +1,13 @@
+FROM ubuntu:19.10
+RUN apt-get update \
+        && apt-get install -y ca-certificates make g++ libssl-dev git wget pkg-config dpkg-dev file cmake \
+        && rm -rf /var/lib/apt/lists/*
+ARG SEABOLT_VERSION
+ARG SEABOLT_VERSION_HASH
+ENV SEABOLT_VERSION=$SEABOLT_VERSION
+ENV SEABOLT_VERSION_HASH=$SEABOLT_VERSION_HASH
+ADD . /tmp/seabolt
+WORKDIR /tmp/seabolt/build-docker
+RUN cmake -D CMAKE_BUILD_TYPE=Release /tmp/seabolt \
+    && cmake --build . --target package
+CMD tar -czf - dist-package/seabolt*


### PR DESCRIPTION
This PR adds following platforms to packaging scripts;

- alpine-3.10
- alpine-3.11
- debian-9 (stretch)
- deban-10 (buster)
- ubuntu-19.10